### PR TITLE
Fixes: expected bytes, got <class 'str'> in download_samples()

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -917,10 +917,10 @@ class PyMISP(object):
                 archive = zipfile.ZipFile(zipped)
                 try:
                     # New format
-                    unzipped = BytesIO(archive.open(f['md5'], pwd='infected').read())
+                    unzipped = BytesIO(archive.open(f['md5'], pwd=b'infected').read())
                 except KeyError:
                     # Old format
-                    unzipped = BytesIO(archive.open(f['filename'], pwd='infected').read())
+                    unzipped = BytesIO(archive.open(f['filename'], pwd=b'infected').read())
                 details.append([f['event_id'], f['filename'], unzipped])
             except zipfile.BadZipfile:
                 # In case the sample isn't zipped


### PR DESCRIPTION
Tested, download_samples() is working now:
```python
misp = pymisp.PyMISP(url, key, ssl=False)
file = misp.download_samples(event_id='1234', all_samples=False)
filename = file[1][0][1]
raw = file[1][0][2]
wrapped = io.TextIOWrapper(raw)
with open(filename, 'w') as afile:
    afile.write(wrapped.read())
```