### PR TITLE
Added test for search_index and solved warnings

### DIFF
--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -216,7 +216,7 @@ class MISPEvent(object):
 
     def __init__(self, describe_types=None):
         self.ressources_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data')
-        with open(os.path.join(self.ressources_path, 'schema.json', 'r') as f:
+        with open(os.path.join(self.ressources_path, 'schema.json'),'r') as f:
             self.json_schema = json.load(f)
         with open(os.path.join(self.ressources_path, 'schema-lax.json'), 'r') as f:
             self.json_schema_lax = json.load(f)

--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -216,8 +216,10 @@ class MISPEvent(object):
 
     def __init__(self, describe_types=None):
         self.ressources_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data')
-        self.json_schema = json.load(open(os.path.join(self.ressources_path, 'schema.json'), 'r'))
-        self.json_schema_lax = json.load(open(os.path.join(self.ressources_path, 'schema-lax.json'), 'r'))
+        with open(os.path.join(self.ressources_path, 'schema.json', 'r') as f:
+            self.json_schema = json.load(f)
+        with open(os.path.join(self.ressources_path, 'schema-lax.json'), 'r') as f:
+            self.json_schema_lax = json.load(f)
         if not describe_types:
             t = json.load(open(os.path.join(self.ressources_path, 'describeTypes.json'), 'r'))
             describe_types = t['result']

--- a/tests/search_index_result.json
+++ b/tests/search_index_result.json
@@ -1,0 +1,69 @@
+[
+  {
+    "id": "3",
+    "org": "",
+    "date": "2016-12-01",
+    "info": "Another random Event",
+    "published": false,
+    "uuid": "5758ebf5-c898-48e6-9fe9-5665c0a83866",
+    "attribute_count": "2",
+    "analysis": "0",
+    "orgc": "",
+    "timestamp": "1465681801",
+    "distribution": "3",
+    "proposal_email_lock": false,
+    "locked": false,
+    "threat_level_id": "1",
+    "publish_timestamp": "0",
+    "sharing_group_id": "0",
+    "org_id": "1",
+    "orgc_id": "1",
+    "Org": {
+      "id": "1",
+      "name": "ORGNAME"
+    },
+    "Orgc": {
+      "id": "1",
+      "name": "ORGNAME"
+    },
+    "EventTag": [
+      {
+        "id": "9760",
+        "event_id": "6028",
+        "tag_id": "4",
+        "Tag": {
+          "id": "4",
+          "name": "TLP:GREEN",
+          "colour": "#33822d",
+          "exportable": true
+        }
+      },
+      {
+        "id": "9801",
+        "event_id": "3",
+        "tag_id": "1",
+        "Tag": {
+          "id": "1",
+          "name": "for_intelmq_processing",
+          "colour": "#00ad1c",
+          "exportable": true
+        }
+      },
+      {
+        "id": "9803",
+        "event_id": "3",
+        "tag_id": "6",
+        "Tag": {
+          "id": "6",
+          "name": "ecsirt:malicious-code=\"ransomware\"",
+          "colour": "#005a5a",
+          "exportable": true
+        }
+      }
+    ],
+    "SharingGroup": {
+      "id": null,
+      "name": null
+    }
+  }
+]

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -21,15 +21,20 @@ class TestOffline(unittest.TestCase):
         self.maxDiff = None
         self.domain = 'http://misp.local/'
         self.key = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        self.event = {'Event': json.load(open('tests/misp_event.json', 'r'))}
-        self.new_misp_event = {'Event': json.load(open('tests/new_misp_event.json', 'r'))}
+        with open('tests/misp_event.json', 'r') as f:
+            self.event = {'Event': json.load(f)}
+        with open('tests/new_misp_event.json', 'r') as f:
+            self.new_misp_event = {'Event': json.load(f)}
         self.ressources_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../pymisp/data')
-        self.types = json.load(open(os.path.join(self.ressources_path, 'describeTypes.json'), 'r'))
-        self.sharing_groups = json.load(open('tests/sharing_groups.json', 'r'))
+        with open(os.path.join(self.ressources_path, 'describeTypes.json'), 'r') as f:
+            self.types = json.load(f)
+        with open('tests/sharing_groups.json', 'r') as f:
+            self.sharing_groups = json.load(f)
         self.auth_error_msg = {"name": "Authentication failed. Please make sure you pass the API key of an API enabled user along in the Authorization header.",
                                "message": "Authentication failed. Please make sure you pass the API key of an API enabled user along in the Authorization header.",
                                "url": "\/events\/1"}
-        self.search_index_result = json.load(open('tests/search_index_result.json', 'r'))
+        with open('tests/search_index_result.json', 'r') as f:
+            self.search_index_result = json.load(f)
 
     def initURI(self, m):
         m.register_uri('GET', self.domain + 'events/1', json=self.auth_error_msg, status_code=403)
@@ -124,7 +129,8 @@ class TestOffline(unittest.TestCase):
         self.initURI(m)
         pymisp = PyMISP(self.domain, self.key)
         misp_event = MISPEvent(pymisp.describe_types)
-        misp_event.load(open('tests/57c4445b-c548-4654-af0b-4be3950d210f.json', 'r').read())
+        with open('tests/57c4445b-c548-4654-af0b-4be3950d210f.json', 'r') as f:
+            misp_event.load(f.read())
         json.dumps(misp_event, cls=EncodeUpdate)
         json.dumps(misp_event, cls=EncodeFull)
 

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -29,6 +29,7 @@ class TestOffline(unittest.TestCase):
         self.auth_error_msg = {"name": "Authentication failed. Please make sure you pass the API key of an API enabled user along in the Authorization header.",
                                "message": "Authentication failed. Please make sure you pass the API key of an API enabled user along in the Authorization header.",
                                "url": "\/events\/1"}
+        self.search_index_result = json.load(open('tests/search_index_result.json', 'r'))
 
     def initURI(self, m):
         m.register_uri('GET', self.domain + 'events/1', json=self.auth_error_msg, status_code=403)
@@ -40,6 +41,7 @@ class TestOffline(unittest.TestCase):
         m.register_uri('DELETE', self.domain + 'events/2', json={'message': 'Event deleted.'})
         m.register_uri('DELETE', self.domain + 'events/3', json={'errors': ['Invalid event'], 'message': 'Invalid event', 'name': 'Invalid event', 'url': '/events/3'})
         m.register_uri('DELETE', self.domain + 'attributes/2', json={'message': 'Attribute deleted.'})
+        m.register_uri('GET', self.domain + 'events/index/searchtag:1', json=self.search_index_result)
 
     def test_getEvent(self, m):
         self.initURI(m)
@@ -125,6 +127,12 @@ class TestOffline(unittest.TestCase):
         misp_event.load(open('tests/57c4445b-c548-4654-af0b-4be3950d210f.json', 'r').read())
         json.dumps(misp_event, cls=EncodeUpdate)
         json.dumps(misp_event, cls=EncodeFull)
+
+    def test_searchIndexByTag (self, m):
+        self.initURI(m)
+        pymisp = PyMISP(self.domain, self.key)
+        response = pymisp.search_index(tag="1")
+        self.assertEqual(response['response'],self.search_index_result)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Nothing functional, just adding a test for search_index, since it was failing in 2.4.50.
While writing the test I realised it was fixed in 2.5.54.

Also, wrapping open() operations in "with" constructs to prevent "file open" warnings while running tests.