### PR TITLE
publish_timestamp Windows 7 Fix

### DIFF
--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -474,7 +474,7 @@ class MISPEvent(object):
         if kwargs.get('locked'):
             self.locked = kwargs['locked']
         if kwargs.get('publish_timestamp'):
-            self.publish_timestamp = datetime.datetime.fromtimestamp(int(kwargs['publish_timestamp']))
+            self.publish_timestamp = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=int(kwargs['publish_timestamp']))
         if kwargs.get('sharing_group_id'):
             self.sharing_group_id = int(kwargs['sharing_group_id'])
         if kwargs.get('Org'):

--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -165,7 +165,7 @@ class MISPAttribute(object):
         if kwargs.get('uuid'):
             self.uuid = kwargs['uuid']
         if kwargs.get('timestamp'):
-            self.timestamp = datetime.datetime.fromtimestamp(int(kwargs['timestamp']))
+            self.timestamp = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=int(kwargs['timestamp']))
         if kwargs.get('sharing_group_id'):
             self.sharing_group_id = int(kwargs['sharing_group_id'])
         if kwargs.get('deleted'):
@@ -468,7 +468,7 @@ class MISPEvent(object):
         if kwargs.get('attribute_count'):
             self.attribute_count = int(kwargs['attribute_count'])
         if kwargs.get('timestamp'):
-            self.timestamp = datetime.datetime.fromtimestamp(int(kwargs['timestamp']))
+            self.timestamp = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=int(kwargs['timestamp']))
         if kwargs.get('proposal_email_lock'):
             self.proposal_email_lock = kwargs['proposal_email_lock']
         if kwargs.get('locked'):


### PR DESCRIPTION
On Windows 7 datetime.datetime.fromtimestamp(int(0)) returns a date before 1970, which causes the script to crash. This fixes the bug.