### PR TITLE
Updated last.py to dump json results straight away

### DIFF
--- a/examples/last.py
+++ b/examples/last.py
@@ -26,9 +26,7 @@ def download_last(m, last, out=None):
             exit(0)
     else:
         with open(out, 'w') as f:
-            for e in result['response']:
-                f.write(json.dumps(e) + '\n')
-
+                f.write(json.dumps(result['response']))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Download latest events from a MISP instance.')

--- a/examples/last.py
+++ b/examples/last.py
@@ -26,7 +26,7 @@ def download_last(m, last, out=None):
             exit(0)
     else:
         with open(out, 'w') as f:
-                f.write(json.dumps(result['response']))
+            f.write(json.dumps(result['response']))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Download latest events from a MISP instance.')


### PR DESCRIPTION
Output was not usable with cli utilities such as: ```cat results.json | python -m simplejson.tool```. 
It's now usable and works perfectly.