### PR TITLE
Fixed the JSON output format (\n breaks JSON loading afterwards)

### DIFF
--- a/examples/last.py
+++ b/examples/last.py
@@ -19,8 +19,7 @@ def download_last(m, last, out=None):
     result = m.download_last(last)
     if out is None:
         if 'response' in result:
-            for e in result['response']:
-                print(json.dumps(e) + '\n')
+            print(json.dumps(result['response']))
         else:
             print('No results for that time period')
             exit(0)

--- a/examples/search.py
+++ b/examples/search.py
@@ -18,12 +18,10 @@ def search(m, quiet, url, controller, out=None, **kwargs):
         for e in result['response']:
             print('{}{}{}\n'.format(url, '/events/view/', e['Event']['id']))
     elif out is None:
-        for e in result['response']:
-            print(json.dumps(e) + '\n')
+        print(json.dumps(result['response']))
     else:
         with open(out, 'w') as f:
-            for e in result['response']:
-                f.write(json.dumps(e) + '\n')
+            f.write(json.dumps(result['response']))
                 
 
 if __name__ == '__main__':

--- a/examples/searchall.py
+++ b/examples/searchall.py
@@ -18,12 +18,10 @@ def searchall(m, search, quiet, url, out=None):
         for e in result['response']:
             print('{}{}{}\n'.format(url, '/events/view/', e['Event']['id']))
     elif out is None:
-        for e in result['response']:
-            print(json.dumps(e) + '\n')
+        print(json.dumps(result['response']))
     else:
         with open(out, 'w') as f:
-            for e in result['response']:
-                f.write(json.dumps(e) + '\n')
+            f.write(json.dumps(result['response']))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Similar to https://github.com/MISP/PyMISP/pull/68, I removed the use of '\n' since it breaks loading JSON with third-party tools afterwards.

Output was not usable with cli utilities such as: 
```bash
cat results.json | python -m simplejson.tool
```
It's now usable and works perfectly.