### PR TITLE
Fix not_values type check in __prepare_rest_search issue #87

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -864,7 +864,7 @@ class PyMISP(object):
                 to_return += '&&!'
             else:
                 to_return += '!'
-            if not isinstance(values, list):
+            if not isinstance(not_values, list):
                 to_return += not_values
             else:
                 to_return += '&&!'.join(not_values)


### PR DESCRIPTION
resolve 87
check for not_values type instead of values when preparing rest query parameters in search API calls

method __prepare_rest_search

@Rafiot  please check it out

thank you