### PR TITLE
added less resourcefull publish_event_silent method

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -371,6 +371,20 @@ class PyMISP(object):
         else:
             eid = e.id
         return self.update_event(eid, e)
+    
+   def publish_event_silent(self, event_id):
+        """Publish event silently (without sending emails)
+        :param eventID: Event id to publish
+        :return publish status
+        """
+        event = self._make_mispevent(self.get_event(event_id))
+        if event.published:
+            return {'error': 'Already published'}
+        else:
+            session = self.__prepare_session()
+            url = urljoin(self.root_url, 'events/publish/{}'.format(event_id))
+            response = session.post(url)
+        return self._check_response(response)
 
     def publish(self, event):
         e = self._make_mispevent(event)


### PR DESCRIPTION
New publish method, depends on the publish misp api method instead of update (same as the web gui silent publish).
After some testing it seems much faster.
notice it after dealing with huge event that gets updates regularly on my systems.
It's also an option to lose the check if the event already published to make it super fast (i use it this way).