### PR TITLE
Formatted "Unknown MISP object" error message

### DIFF
--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -604,7 +604,7 @@ class MISPObject(AbstractMISP):
             self.__known_template = True
         else:
             if self.__strict:
-                raise UnknownMISPObjectTemplate('{} is unknown in the MISP object directory.')
+                raise UnknownMISPObjectTemplate('{} is unknown in the MISP object directory.'.format(self.name))
             else:
                 self.__known_template = False
         if self.__known_template:


### PR DESCRIPTION
When a user tries to add an object with a name that doesn't exist, the error thrown was missing its format string
This ended up looking like:
```
pymisp.exceptions.UnknownMISPObjectTemplate: {} is unknown in the MISP object directory.
```
Here's a patch that adds self.name to the format string