### PR TITLE
Similar to #114 on attribute level

### DIFF
--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -76,6 +76,7 @@ class MISPAttribute(AbstractMISP):
         self._types = describe_types['types']
         self.__category_type_mapping = describe_types['category_type_mappings']
         self.__sane_default = describe_types['sane_defaults']
+        self.Tag = []
 
     def _reinitialize_attribute(self):
         # Default values


### PR DESCRIPTION
`add_attribute_tag(tag,attribute_identifier)` fails if attribute does not have any tag in before.

Side note: It would be better if the creation of tags at attribute level would be possible even before the first saving of the event. It would be easily possible by change the if statement `if (a.id == attribute_identifier or a.uuid == attribute_identifier or
                    attribute_identifier == a.value or attribute_identifier in a.value.split('|')):` in a way that it does not fail in case of non-existent db attributes (`uuid,id`)