### PR TITLE
Added **kwargs to add_named_attribute call in add_attachment

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -535,7 +535,7 @@ class PyMISP(object):
         encodedData = base64.b64encode(fileData).decode("utf-8")
 
         # Send it on its way
-        return self.add_named_attribute(event, 'attachment', filename, category, to_ids, comment, distribution, proposal, data=encodedData)
+        return self.add_named_attribute(event, 'attachment', filename, category, to_ids, comment, distribution, proposal, data=encodedData, **kwargs)
 
     def add_regkey(self, event, regkey, rvalue=None, category='Artifacts dropped', to_ids=True, comment=None, distribution=None, proposal=False, **kwargs):
         if rvalue:


### PR DESCRIPTION
Added change so I could pass additional params to the the add_attachment. In my case it was "disable_correlation=True". It never actually made it down to the add_named_attribute b/c it was misssing **kwargs.  