### PR TITLE
Check explicitly for a 500 response from the server with no response content

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -223,13 +223,16 @@ class PyMISP(object):
         """Check if the response from the server is not an unexpected error"""
         errors = []
         if response.status_code >= 500:
-            errors.append(response.json())
-            logger.critical('Something bad happened on the server-side: {}'.format(response.json()))
+            if len(response.content) == 0:
+                raise PyMISPError('Something bad happened on the server-side and there was no content to be decoded')
+            else:
+                errors.append(response.json())
+                logger.critical('Something bad happened on the server-side: {}'.format(response.json()))
         try:
             to_return = response.json()
         except ValueError:
             # It the server didn't return a JSON blob, we've a problem.
-            raise PyMISPError('Unknown error (something is very broken server-side: {}'.format(response.text))
+            raise PyMISPError('Unknown error (something is very broken server-side: {})'.format(response.text))
 
         if isinstance(to_return, (list, str)):
             to_return = {'response': to_return}

--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -224,7 +224,7 @@ class PyMISP(object):
         errors = []
         if response.status_code >= 500:
             if len(response.content) == 0:
-                raise PyMISPError('Something bad happened on the server-side and there was no content to be decoded')
+                raise PyMISPError('Something bad happened on the server-side, but there was no response content to be decoded')
             else:
                 errors.append(response.json())
                 logger.critical('Something bad happened on the server-side: {}'.format(response.json()))


### PR DESCRIPTION
Further details can be found in the commit messages.

I aim to next look at what the server is doing with my request that it sometimes generates a 500 response with an internal error message, but most often generates a 500 response with no content.