### PR TITLE
Add get_only param

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -77,9 +77,10 @@ class PyMISP(object):
     :param proxies: Proxy dict as describes here: http://docs.python-requests.org/en/master/user/advanced/#proxies
     :param cert: Client certificate, as described there: http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
     :param asynch: Use asynchronous processing where possible
+    :param get_only: can be True or False. If True the methods for making changes in misp are deactivated.
     """
 
-    def __init__(self, url, key, ssl=True, out_type='json', debug=None, proxies=None, cert=None, asynch=False):
+    def __init__(self, url, key, ssl=True, out_type='json', debug=None, proxies=None, cert=None, asynch=False, get_only=False):
         if not url:
             raise NoURL('Please provide the URL of your MISP instance.')
         if not key:
@@ -101,34 +102,42 @@ class PyMISP(object):
         if debug:
             logger.setLevel(logging.DEBUG)
             logger.info('To configure logging in your script, leave it to None and use the following: import logging; logging.getLogger(\'pymisp\').setLevel(logging.DEBUG)')
+        if get_only:
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug('get_only is active')
+            methodes_to_disable = ["add_", "change_", "delete_", "edit_", "fast_", "new_", "proposal_", "publish", "set_", "sighting_", "tag", "untag", "update"]
+            for methode_name in dir(self.__class__):
+                for m in methodes_to_disable:
+                    if methode_name.startswith(m):
+                        delattr(self.__class__,methode_name)
+        else:
+            try:
+                # Make sure the MISP instance is working and the URL is valid
+                response = self.get_recommended_api_version()
+                if response.get('errors'):
+                    logger.warning(response.get('errors')[0])
+                elif not response.get('version'):
+                    logger.warning("Unable to check the recommended PyMISP version (MISP <2.4.60), please upgrade.")
+                else:
+                    pymisp_version_tup = tuple(int(x) for x in __version__.split('.'))
+                    recommended_version_tup = tuple(int(x) for x in response['version'].split('.'))
+                    if recommended_version_tup < pymisp_version_tup[:3]:
+                        logger.info("The version of PyMISP recommended by the MISP instance ({}) is older than the one you're using now ({}). If you have a problem, please upgrade the MISP instance or use an older PyMISP version.".format(response['version'], __version__))
+                    elif pymisp_version_tup[:3] < recommended_version_tup:
+                        logger.warning("The version of PyMISP recommended by the MISP instance ({}) is newer than the one you're using now ({}). Please upgrade PyMISP.".format(response['version'], __version__))
 
-        try:
-            # Make sure the MISP instance is working and the URL is valid
-            response = self.get_recommended_api_version()
-            if response.get('errors'):
-                logger.warning(response.get('errors')[0])
-            elif not response.get('version'):
-                logger.warning("Unable to check the recommended PyMISP version (MISP <2.4.60), please upgrade.")
-            else:
-                pymisp_version_tup = tuple(int(x) for x in __version__.split('.'))
-                recommended_version_tup = tuple(int(x) for x in response['version'].split('.'))
-                if recommended_version_tup < pymisp_version_tup[:3]:
-                    logger.info("The version of PyMISP recommended by the MISP instance ({}) is older than the one you're using now ({}). If you have a problem, please upgrade the MISP instance or use an older PyMISP version.".format(response['version'], __version__))
-                elif pymisp_version_tup[:3] < recommended_version_tup:
-                    logger.warning("The version of PyMISP recommended by the MISP instance ({}) is newer than the one you're using now ({}). Please upgrade PyMISP.".format(response['version'], __version__))
+            except Exception as e:
+                raise PyMISPError('Unable to connect to MISP ({}). Please make sure the API key and the URL are correct (http/https is required): {}'.format(self.root_url, e))
 
-        except Exception as e:
-            raise PyMISPError('Unable to connect to MISP ({}). Please make sure the API key and the URL are correct (http/https is required): {}'.format(self.root_url, e))
+            try:
+                self.describe_types = self.get_live_describe_types()
+            except Exception:
+                self.describe_types = self.get_local_describe_types()
 
-        try:
-            self.describe_types = self.get_live_describe_types()
-        except Exception:
-            self.describe_types = self.get_local_describe_types()
-
-        self.categories = self.describe_types['categories']
-        self.types = self.describe_types['types']
-        self.category_type_mapping = self.describe_types['category_type_mappings']
-        self.sane_default = self.describe_types['sane_defaults']
+            self.categories = self.describe_types['categories']
+            self.types = self.describe_types['types']
+            self.category_type_mapping = self.describe_types['category_type_mappings']
+            self.sane_default = self.describe_types['sane_defaults']
 
     def get_live_query_acl(self):
         """This should return an empty list, unless the ACL is outdated."""


### PR DESCRIPTION
When get_only is True the methods for making changes in misp are deactivated.

This parameter can be used when you don't need to check the version of misp and don't load the elements specific to the check made when you add it.
It can also be interesting if your network is slow. Maybe ...

Deactivated methods are in the list  **methodes_to_disable**.

how to test : 
```python
misp = PyMISP(mispUrl, mispKey)
r = misp.tag(attrUuid, 'test:sample="one"')
print(json.dumps(r, indent=4))
r = misp.untag(attrUuid,'test:sample="one"')
print(json.dumps(r, indent=4))
```
all works ^^
but : 
```python
misp = PyMISP(mispUrl, mispKey, get_only=True)
r = misp.tag("58161ef2-c9a8-4b13-8b3a-418c02de0b81", 'test:toto=".com"')
print(json.dumps(r, indent=4))
```
display an error : 
```bash
AttributeError: 'PyMISP' object has no attribute 'tag'
```

but something like : 
```python
misp = PyMISP(mispUrl, mispKey, get_only=True)
r = misp.search(timestamp="1511823600")
for a in r['response']:
	print(a['Event']['id'])
```
return : 
```bash
300
460
```