### PR TITLE
fix: AbstractMISP.from_dict() do not accept positional argument

### DIFF
--- a/pymisp/abstract.py
+++ b/pymisp/abstract.py
@@ -95,7 +95,7 @@ class AbstractMISP(collections.MutableMapping):
 
     def from_json(self, json_string):
         """Load a JSON string"""
-        self.from_dict(json.loads(json_string))
+        self.from_dict(**json.loads(json_string))
 
     def to_dict(self):
         """Dump the lass to a dictionary.


### PR DESCRIPTION
Doing the following raise an exception:
```
json = '''{
    "type": "ip-src",
    "value": "8.8.8.8",
    "category": "Network activity",
    "to_ids": false,
    "proposal": false
    }'''
attribute = MISPAttribute()
attribute.from_json(json)
```
TypeError: from_dict() takes 1 positional argument but 2 were given
