### PR TITLE
Update default category for url

### DIFF
--- a/pymisp/data/describeTypes.json
+++ b/pymisp/data/describeTypes.json
@@ -78,7 +78,7 @@
         "to_ids": 0
       },
       "url": {
-        "default_category": "External analysis",
+        "default_category": "Network activity",
         "to_ids": 1
       },
       "http-method": {


### PR DESCRIPTION
As described in https://github.com/MISP/MISP/pull/3119, `External analysis` is not that good as a default category from my point of view. To complete the change of default category type it has to be changed in `pymisp/data/describeTypes.json`, too.