### PR TITLE
chg: fix sample retrieval from new-style zips

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -1210,7 +1210,7 @@ class PyMISP(object):
             zipped = BytesIO(decoded)
             try:
                 archive = zipfile.ZipFile(zipped)
-                if f.get('md5') and f['md5'] in archive.infolist():
+                if f.get('md5') and f['md5'] in archive.namelist():
                     # New format
                     unzipped = BytesIO(archive.open(f['md5'], pwd=b'infected').read())
                 else:


### PR DESCRIPTION
Hi,
The check for detecting zip style (old or new) fails, because comparing a ZipInfo object with a string (file name) doesn't seem to be implemented.
This patch fixes it.
Thanks for considering this pull request.