### PR TITLE
align examples on custom usage of misp_verifycert

### DIFF
--- a/examples/add_named_attribute.py
+++ b/examples/add_named_attribute.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
 # For python2 & 3 compat, a bit dirty, but it seems to be the least bad one
@@ -13,7 +13,7 @@ except NameError:
 
 
 def init(url, key):
-    return PyMISP(url, key, True, 'json', debug=True)
+    return PyMISP(url, key, misp_verifycert, 'json', debug=True)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Add an attribute to an event')

--- a/examples/add_user.py
+++ b/examples/add_user.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
 # For python2 & 3 compat, a bit dirty, but it seems to be the least bad one
@@ -13,7 +13,7 @@ except NameError:
 
 
 def init(url, key):
-    return PyMISP(url, key, True, 'json')
+    return PyMISP(url, key, misp_verifycert, 'json')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Add a new user by setting the mandory fields.')

--- a/examples/add_user_json.py
+++ b/examples/add_user_json.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
 # For python2 & 3 compat, a bit dirty, but it seems to be the least bad one
@@ -13,7 +13,7 @@ except NameError:
 
 
 def init(url, key):
-    return PyMISP(url, key, True, 'json')
+    return PyMISP(url, key, misp_verifycert, 'json')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Add  the user described in the given json. If no file is provided, returns a json listing all the fields used to describe a user.')

--- a/examples/create_events.py
+++ b/examples/create_events.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
 # For python2 & 3 compat, a bit dirty, but it seems to be the least bad one
@@ -13,7 +13,7 @@ except NameError:
 
 
 def init(url, key):
-    return PyMISP(url, key, True, 'json', debug=True)
+    return PyMISP(url, key, misp_verifycert, 'json', debug=True)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Create an event on MISP.')

--- a/examples/delete_user.py
+++ b/examples/delete_user.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
 # For python2 & 3 compat, a bit dirty, but it seems to be the least bad one
@@ -13,7 +13,7 @@ except NameError:
 
 
 def init(url, key):
-    return PyMISP(url, key, True, 'json')
+    return PyMISP(url, key, misp_verifycert, 'json')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Delete the user with the given id. Keep in mind that disabling users (by setting the disabled flag via an edit) is always prefered to keep user associations to events intact.')

--- a/examples/edit_user.py
+++ b/examples/edit_user.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
 # For python2 & 3 compat, a bit dirty, but it seems to be the least bad one
@@ -13,7 +13,7 @@ except NameError:
 
 
 def init(url, key):
-    return PyMISP(url, key, True, 'json')
+    return PyMISP(url, key, misp_verifycert, 'json')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Edit the email of the user designed by the user_id.')

--- a/examples/edit_user_json.py
+++ b/examples/edit_user_json.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
 # For python2 & 3 compat, a bit dirty, but it seems to be the least bad one
@@ -13,7 +13,7 @@ except NameError:
 
 
 def init(url, key):
-    return PyMISP(url, key, True, 'json')
+    return PyMISP(url, key, misp_verifycert, 'json')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Edit the user designed by the user_id. If no file is provided, returns a json listing all the fields used to describe a user.')

--- a/examples/et2misp.py
+++ b/examples/et2misp.py
@@ -9,14 +9,14 @@
 
 import sys, json, time, requests
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 
 et_url = 'https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt'
 et_str = 'Emerging Threats '
 
 def init_misp():
     global mymisp
-    mymisp = PyMISP(misp_url, misp_key)
+    mymisp = PyMISP(misp_url, misp_key, misp_verifycert)
 
 def load_misp_event(eid):
     global et_attr

--- a/examples/fetch_events_feed.py
+++ b/examples/fetch_events_feed.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 from pymisp import PyMISP
 
@@ -12,7 +12,7 @@ except NameError:
     pass
     
 def init(url, key):
-    return PyMISP(url, key, False, 'json', debug=False)
+    return PyMISP(url, key, misp_verifycert, 'json', debug=False)
 
 
 if __name__ == '__main__':

--- a/examples/freetext.py
+++ b/examples/freetext.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
 from io import open
@@ -15,7 +15,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    pymisp = PyMISP(misp_url, misp_key)
+    pymisp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     with open(args.input, 'r') as f:
         result = pymisp.freetext(args.event, f.read())

--- a/examples/misp2cef.py
+++ b/examples/misp2cef.py
@@ -7,7 +7,7 @@
 import sys
 import datetime
 from pymisp import PyMISP, MISPAttribute
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 
 cefconfig  = {"Default_Severity":1, "Device_Vendor":"MISP", "Device_Product":"MISP", "Device_Version":1}
 
@@ -45,7 +45,7 @@ def make_cef(event):
 
 def init_misp():
   global mymisp
-  mymisp = PyMISP(misp_url, misp_key)
+  mymisp = PyMISP(misp_url, misp_key, misp_verifycert)
 
 
 def echeck(r):

--- a/examples/misp2clamav.py
+++ b/examples/misp2clamav.py
@@ -6,12 +6,12 @@
 
 import sys
 from pymisp import PyMISP, MISPAttribute
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 
 
 def init_misp():
     global mymisp
-    mymisp = PyMISP(misp_url, misp_key)
+    mymisp = PyMISP(misp_url, misp_key, misp_verifycert)
 
 
 def echeck(r):

--- a/examples/sharing_groups.py
+++ b/examples/sharing_groups.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
 # For python2 & 3 compat, a bit dirty, but it seems to be the least bad one
@@ -13,7 +13,7 @@ except NameError:
 
 
 def init(url, key):
-    return PyMISP(url, key, True, 'json')
+    return PyMISP(url, key, misp_verifycert, 'json')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Get a list of the sharing groups from the MISP instance.')

--- a/examples/sighting.py
+++ b/examples/sighting.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
 # For python2 & 3 compat, a bit dirty, but it seems to be the least bad one
@@ -13,7 +13,7 @@ except NameError:
 
 
 def init(url, key):
-    return PyMISP(url, key, True, 'json')
+    return PyMISP(url, key, misp_verifycert, 'json')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Add sighting.')

--- a/examples/suricata.py
+++ b/examples/suricata.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
 
 def init(url, key):
-    return PyMISP(url, key, True)
+    return PyMISP(url, key, misp_verifycert)
 
 
 def fetch(m, all_events, event):

--- a/examples/tags.py
+++ b/examples/tags.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 import json
 
 
 def init(url, key):
-    return PyMISP(url, key, True, 'json', True)
+    return PyMISP(url, key, misp_verifycert, 'json', True)
 
 
 def get_tags(m):

--- a/examples/up.py
+++ b/examples/up.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
 from io import open
 
 def init(url, key):
-    return PyMISP(url, key, True, 'json', debug=True)
+    return PyMISP(url, key, misp_verifycert, 'json', debug=True)
 
 def up_event(m, event, content):
     with open(content, 'r') as f:

--- a/examples/users_list.py
+++ b/examples/users_list.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
 # For python2 & 3 compat, a bit dirty, but it seems to be the least bad one
@@ -13,7 +13,7 @@ except NameError:
 
 
 def init(url, key):
-    return PyMISP(url, key, True, 'json')
+    return PyMISP(url, key, misp_verifycert, 'json')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Get a list of the sharing groups from the MISP instance.')

--- a/examples/warninglists.py
+++ b/examples/warninglists.py
@@ -4,7 +4,7 @@
 from pymisp import PyMISP
 from pymisp.tools import load_warninglists
 import argparse
-from keys import misp_url, misp_key
+from keys import misp_url, misp_key, misp_verifycert
 
 
 if __name__ == '__main__':
@@ -18,5 +18,5 @@ if __name__ == '__main__':
     if args.package:
         print(load_warninglists.from_package())
     elif args.remote:
-        pm = PyMISP(misp_url, misp_key)
+        pm = PyMISP(misp_url, misp_key, misp_verifycert)
         print(load_warninglists.from_instance(pm))


### PR DESCRIPTION
part of examples scripts had True value whereas there is a custom setting for certificate validation used in others.
required for automated pipeline testing with self-signed certificate.