### PR TITLE
Add new function PyMISP.change_disablecorrelation()

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -1032,6 +1032,13 @@ class PyMISP(object):
         query = {"comment": comment}
         return self.__query('edit/{}'.format(attribute_uuid), query, controller='attributes')
 
+    def change_disablecorrelation(self, attribute_uuid, disable_correlation):
+        """Change the disable_correlation flag"""
+        if disable_correlation not in [0, 1]:
+            raise Exception('disable_correlation can only be 0 or 1')
+        query = {"disable_correlation": disable_correlation}
+        return self.__query('edit/{}'.format(attribute_uuid), query, controller='attributes')
+
     # ##############################
     # ###### Attribute update ######
     # ##############################

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -409,6 +409,20 @@ class TestOffline(unittest.TestCase):
         except Exception:
             pass
 
+    def test_change_disablecorrelation(self, m):
+        self.initURI(m)
+        pymisp = PyMISP(self.domain, self.key)
+        self.assertEqual({}, pymisp.change_disable_correlation(self.key, 1))
+
+    def test_change_disablecorrelation_invalid(self, m):
+        self.initURI(m)
+        pymisp = PyMISP(self.domain, self.key)
+        try:
+            pymisp.change_disablecorrelation(self.key, 42)
+            self.assertFalse('Exception required for off domain value')
+        except Exception:
+            pass
+
     def test_proposal_view_default(self, m):
         self.initURI(m)
         pymisp = PyMISP(self.domain, self.key)

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -412,7 +412,7 @@ class TestOffline(unittest.TestCase):
     def test_change_disablecorrelation(self, m):
         self.initURI(m)
         pymisp = PyMISP(self.domain, self.key)
-        self.assertEqual({}, pymisp.change_disable_correlation(self.key, 1))
+        self.assertEqual({}, pymisp.change_disablecorrelation(self.key, 1))
 
     def test_change_disablecorrelation_invalid(self, m):
         self.initURI(m)


### PR DESCRIPTION
Add new function `PyMISP.change_disablecorrelation(attribute_uuid,disable_correlation)` to be able to enable/disable correlation on attributes.

The goal is to be able to enable or disable correlation on single attribute as you can do with ids flag.