### PR TITLE
 new: [tools] Build MIME type MISP object from a file. 

### DIFF
--- a/examples/add_metadata_object.py
+++ b/examples/add_metadata_object.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from pymisp import PyMISP
+from pymisp.tools.mimetypeobject import MIMETypeObject
+
+import traceback
+from keys import misp_url, misp_key, misp_verifycert
+import glob
+import argparse
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Extract metadata out of file and add MISP object to a MISP instance.')
+    parser.add_argument("-e", "--event", required=True, help="Event ID to update.")
+    parser.add_argument("-p", "--path", required=True, help="Path to file (expanded using glob).")
+    args = parser.parse_args()
+
+    pymisp = PyMISP(misp_url, misp_key, misp_verifycert)
+
+    for f in glob.glob(args.path):
+        try:
+            mispObject = MIMETypeObject(filepath=f)
+        except Exception as e:
+            traceback.print_exc()
+            continue
+
+        if mispObject:
+            r = pymisp.add_object(args.event, mispObject)
+

--- a/examples/add_metadata_object.py
+++ b/examples/add_metadata_object.py
@@ -1,5 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+#
+#
+#    A simple tool to add file metadata objects to a MISP event.
+#    Copyright (C) 2019 Roger Johnston
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pymisp import PyMISP
 from pymisp.tools.mimetypeobject import MIMETypeObject

--- a/examples/add_metadata_object.py
+++ b/examples/add_metadata_object.py
@@ -43,4 +43,3 @@ if __name__ == '__main__':
 
         if mispObject:
             r = pymisp.add_object(args.event, mispObject)
-

--- a/pymisp/tools/__init__.py
+++ b/pymisp/tools/__init__.py
@@ -15,6 +15,7 @@ from .fail2banobject import Fail2BanObject  # noqa
 from .domainipobject import DomainIPObject  # noqa
 from .asnobject import ASNObject  # noqa
 from .geolocationobject import GeolocationObject  # noqa
+from .mimetypeobject import MIMETypeObject  # noqa
 
 if sys.version_info >= (3, 6):
     from .emailobject import EMailObject  # noqa

--- a/pymisp/tools/mimetypeobject.py
+++ b/pymisp/tools/mimetypeobject.py
@@ -100,10 +100,9 @@ class MIMETypeObject(AbstractMISPObjectGenerator):
 
         for k, v in file_metadata.items():
             sanitized_key_name = re.sub(r'\W', '-', k)
-            if type(v) is None:
+            if v is None:
                 pass
             elif v == '':
                 pass
             else:
                 self.add_attribute(sanitized_key_name, value=v)
-

--- a/pymisp/tools/mimetypeobject.py
+++ b/pymisp/tools/mimetypeobject.py
@@ -1,5 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+#
+#
+#    A simple tool to build to file metadata objects.
+#    Copyright (C) 2019 Roger Johnston
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from ..exceptions import InvalidMISPObject
 from .abstractgenerator import AbstractMISPObjectGenerator

--- a/pymisp/tools/mimetypeobject.py
+++ b/pymisp/tools/mimetypeobject.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from ..exceptions import InvalidMISPObject
+from .abstractgenerator import AbstractMISPObjectGenerator
+from io import BytesIO
+import logging
+import os
+import codecs
+import json
+import subprocess
+import re
+
+logger = logging.getLogger('pymisp')
+
+try:
+    import magic
+    HAS_MAGIC = True
+except ImportError:
+    HAS_MAGIC = False
+
+
+class MIMETypeObject(AbstractMISPObjectGenerator):
+
+    def __init__(self, filepath=None, pseudofile=None, filename=None, standalone=True, **kwargs):
+        if not HAS_MAGIC:
+            logger.warning("Please install python-magic: pip install python-magic.")
+        if filename:
+            # Useful in case the file is copied with a pre-defined name by a script but we want to keep the original name
+            self.__filename = filename
+        elif filepath:
+            self.__filename = os.path.basename(filepath)
+        else:
+            raise InvalidMISPObject('A file name is required (either in the path, or as a parameter).')
+
+        if filepath:
+            with open(filepath, 'rb') as f:
+                self.__pseudofile = BytesIO(f.read())
+        elif pseudofile and isinstance(pseudofile, BytesIO):
+            # WARNING: lief.parse requires a path
+            self.__pseudofile = pseudofile
+        else:
+            raise InvalidMISPObject('File buffer (BytesIO) or a path is required.')
+
+        mime = magic.from_buffer(self.__pseudofile.getvalue(), mime=True)
+        mime_type = re.sub(r'\W', '-', mime)
+
+        # PY3 way:
+        # super().__init__('file')
+        super(MIMETypeObject, self).__init__('MIME-' + mime_type, standalone=standalone, **kwargs)
+        self.__data = self.__pseudofile.getvalue()
+
+        self.generate_attributes()
+
+    def base64_encode_bytes(self, pseudofile):
+        """
+        Base64 encodes bytes for passing self.__pseudofile to subprocess.
+        :return:
+        """
+        return codecs.encode(pseudofile, 'base64')
+
+    def extract_exif(self, base64_string):
+        """
+        Uses ExifTool via subprocess to extract file metadata.
+        :return:
+        """
+        p1 = subprocess.Popen(("echo", base64_string), stdout=subprocess.PIPE)
+        p2 = subprocess.Popen(("base64", "--decode"), stdin=p1.stdout, stdout=subprocess.PIPE)
+        p3 = subprocess.Popen(("exiftool", "-G", "-n", "-j", "-"), stdin=p2.stdout, stdout=subprocess.PIPE)
+        output = p3.communicate()[0]
+        return json.loads(output.decode('utf-8'))[0]
+
+    def generate_attributes(self):
+        """
+        Adds attributes from ExifTool output.
+        :return:
+        """
+        base64_file = self.base64_encode_bytes(self.__data)
+
+        file_metadata = self.extract_exif(base64_file)
+
+        self.add_attribute('source-file', value=self.__filename)
+
+        for k, v in file_metadata.items():
+            sanitized_key_name = re.sub(r'\W', '-', k)
+            if type(v) is None:
+                pass
+            elif v == '':
+                pass
+            else:
+                self.add_attribute(sanitized_key_name, value=v)
+


### PR DESCRIPTION
Use python-magic and ExifTool to extract file metadata. Requires misp-objects PR 171: https://github.com/MISP/misp-objects/pull/171