### PR TITLE
Resolve issue with change_sharing_group which do not update event suc…

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -513,7 +513,9 @@ class PyMISP(object):
         """Change the sharing group of an event"""
         e = self._make_mispevent(event)
         e.distribution = 4      # Needs to be 'Sharing group'
-        e.sharing_group_id = sharing_group_id
+        if e.SharingGroup:      # Delete former SharingGroup information
+            del e.SharingGroup
+        e.sharing_group_id = sharing_group_id # Set new sharing group id
         return self.update(e)
 
     def new_event(self, distribution=None, threat_level_id=None, analysis=None, info=None, date=None, published=False, orgc_id=None, org_id=None, sharing_group_id=None):


### PR DESCRIPTION
…cessfully.

I noticed that event sharing group are not successfully updated when using function "change_sharing_group".
In fact its because you need not only to update event.sharing_group_id but also delete former sharing group detailed information i.e. event.SharingGroup.
