### PR TITLE
[OpenIOC] Allow the use of content type for RouteEntryItem/Destination

### DIFF
--- a/pymisp/tools/openioc.py
+++ b/pymisp/tools/openioc.py
@@ -218,7 +218,11 @@ def set_values(value1, value2=None):
         compositeMapping = '{}|{}'.format(value1.find('context')['search'], value2.find('context')['search'])
         mapping = get_mapping(compositeMapping, mappingDict=iocMispCompositeMapping)
     else:
-        mapping = get_mapping(value1.find('context')['search'])
+        content_type = value1.find('content').get('type', None)
+        if content_type:
+            mapping = get_mapping(value1.find('context')['search'] + '/' + content_type)
+        else:
+            mapping = get_mapping(value1.find('context')['search'])
 
     if mapping:
         attribute_values.update(mapping)

--- a/pymisp/tools/openioc.py
+++ b/pymisp/tools/openioc.py
@@ -100,7 +100,7 @@ iocMispMapping = {
 
     'RouteEntryItem/Destination': {'type': 'ip-dst'},
     'RouteEntryItem/Destination/IP': {'type': 'ip-dst', 'comment': 'RouteDestination. '},
-    'RouteEntryItem/Destination/string': {'type': 'domain', 'comment': 'RouteDestination. '},
+    'RouteEntryItem/Destination/string': {'type': 'hostname', 'comment': 'RouteDestination. '},
 
 
     'ServiceItem/name': {'type': 'windows-service-name'},

--- a/pymisp/tools/openioc.py
+++ b/pymisp/tools/openioc.py
@@ -218,11 +218,12 @@ def set_values(value1, value2=None):
         compositeMapping = '{}|{}'.format(value1.find('context')['search'], value2.find('context')['search'])
         mapping = get_mapping(compositeMapping, mappingDict=iocMispCompositeMapping)
     else:
+        context_search = value1.find('context')['search']
         content_type = value1.find('content').get('type', None)
-        if content_type:
-            mapping = get_mapping(value1.find('context')['search'] + '/' + content_type)
+        if "RouteEntryItem/Destination" in context_search and content_type:
+            mapping = get_mapping(context_search + '/' + content_type)
         else:
-            mapping = get_mapping(value1.find('context')['search'])
+            mapping = get_mapping(context_search)
 
     if mapping:
         attribute_values.update(mapping)

--- a/pymisp/tools/openioc.py
+++ b/pymisp/tools/openioc.py
@@ -100,7 +100,7 @@ iocMispMapping = {
 
     'RouteEntryItem/Destination': {'type': 'ip-dst'},
     'RouteEntryItem/Destination/IP': {'type': 'ip-dst', 'comment': 'RouteDestination. '},
-    'RouteEntryItem/Destination/string': {'type': 'url', 'comment': 'RouteDestination. '},
+    'RouteEntryItem/Destination/string': {'type': 'domain', 'comment': 'RouteDestination. '},
 
 
     'ServiceItem/name': {'type': 'windows-service-name'},


### PR DESCRIPTION
The commits allow the use of
- `RouteEntryItem/Destination/IP`
- `RouteEntryItem/Destination/string`

as they are given in the mapping, but never used. I explicitly check for `RouteEntryItem/Destination` in the Context > search xml attribute, because there might be some side effects if implemented in a more generic way.  

Also, the default mapping for `RouteEntryItem/Destination/string` has been changed to `hostname` instead of `url`. This makes sense to me, because a URL includes a scheme usually and at this point of the mapping there would otherwise be a distinction between `IP` ("schemeless") and `url` (scheme required). 