### PR TITLE
Fix missing f in f-string

### DIFF
--- a/pymisp/aping.py
+++ b/pymisp/aping.py
@@ -1841,7 +1841,7 @@ class ExpandedPyMISP(PyMISP):
             url = f'{url}/{to_append_url}'
         req = requests.Request(request_type, url, data=data, params=params)
         with requests.Session() as s:
-            user_agent = 'PyMISP {__version__} - Python {".".join(str(x) for x in sys.version_info[:2])}'
+            user_agent = f'PyMISP {__version__} - Python {".".join(str(x) for x in sys.version_info[:2])}'
             if self.tool:
                 user_agent = f'{user_agent} - {self.tool}'
             req.auth = self.auth


### PR DESCRIPTION
Fixes: #429

Same request as in the issue now produces:

```
GET /servers/getPyMISPVersion.json HTTP/1.1
Host: localhost:1337
User-Agent: PyMISP 2.4.111.2 - Python 3.7
Accept-Encoding: gzip, deflate
Accept: application/json
Connection: keep-alive
Authorization: asdf
content-type: application/json
```