### PR TITLE
chg: Return empty list instead of None

### DIFF
--- a/pymisp/tools/create_misp_object.py
+++ b/pymisp/tools/create_misp_object.py
@@ -90,4 +90,4 @@ def make_binary_objects(filepath=None, pseudofile=None, filename=None, standalon
             logger.warning(e)
     if not HAS_LIEF:
         logger.warning('Please install lief, documentation here: https://github.com/lief-project/LIEF')
-    return misp_file, None, None
+    return misp_file, None, []


### PR DESCRIPTION
In all cases but one, the 3rd returned object is a (potentially empty) list.