### PR TITLE
Make client_certs out of the box friendly

### DIFF
--- a/examples/keys.py.sample
+++ b/examples/keys.py.sample
@@ -4,3 +4,4 @@
 misp_url = 'https://<your MISP URL>/'
 misp_key = 'Your MISP auth key' # The MISP auth key can be found on the MISP web interface under the automation section
 misp_verifycert = True
+misp_client_cert = ''

--- a/examples/last.py
+++ b/examples/last.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pymisp import ExpandedPyMISP
-from keys import misp_url, misp_key, misp_verifycert
+from keys import misp_url, misp_key, misp_verifycert, misp_client_cert
 import argparse
 import os
 
@@ -23,7 +23,12 @@ if __name__ == '__main__':
         print('Output file already exists, aborted.')
         exit(0)
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    if misp_client_cert == '':
+        misp_client_cert = None
+    else:
+        misp_client_cert = (misp_client_cert)
+
+    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert, cert=misp_client_cert)
     result = misp.search(publish_timestamp=args.last, limit=args.limit, page=args.page, pythonify=True)
 
     if not result:


### PR DESCRIPTION
Example of misp_client_cert a path 'string', which gets converted to a tuple.
misp_client_cert = '/home/cam/MISP_Cert.pem'

MISP_Cert.pem would contain both the private key and the certificate in PEM format.
