### PR TITLE
Update .gitignore to exclude files produced during tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,10 @@ examples/cudeso.py
 examples/feed-generator/output/*\.json
 examples/feed-generator/output/hashes\.csv
 examples/feed-generator/settings\.py
+tests/reportlab_testoutputs/*\.pdf
 build/*
 dist/*
 pymisp.egg-info/*
+.coverage
 .idea
 


### PR DESCRIPTION
Exclude the following files from git:

- .coverage
- tests/reportlab_testoutputs/*.pdf