### PR TITLE
Add viper-test-files repository as Git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "pymisp/tools/pdf_fonts"]
 	path = pymisp/tools/pdf_fonts
 	url = https://github.com/MISP/pdf_fonts
+[submodule "tests/viper-test-files"]
+	path = tests/viper-test-files
+	url = https://github.com/viper-framework/viper-test-files.git


### PR DESCRIPTION
Since the files are required for the tests anyway, I think it makes sense to have them as a Git submodule, just like the MISP object definitions.