### PR TITLE
Corrected docstring

### DIFF
--- a/pymisp/aping.py
+++ b/pymisp/aping.py
@@ -1390,7 +1390,7 @@ class ExpandedPyMISP(PyMISP):
                **kwargs):
         '''Search in the MISP instance
 
-        :param returnFormat: Set the return format of the search (Currently supported: json, xml, openioc, suricata, snort - more formats are being moved to restSearch with the goal being that all searches happen through this API). Can be passed as the first parameter after restSearch or via the JSON payload.
+        :param return_format: Set the return format of the search (Currently supported: json, xml, openioc, suricata, snort - more formats are being moved to restSearch with the goal being that all searches happen through this API). Can be passed as the first parameter after restSearch or via the JSON payload.
         :param limit: Limit the number of results returned, depending on the scope (for example 10 attributes or 10 full events).
         :param page: If a limit is set, sets the page to be returned. page 3, limit 100 will return records 201->300).
         :param value: Search for the given value in the attributes' value field.


### PR DESCRIPTION
I just stumbled over the keyword args of the PyMISPExpanded.search method. The documentation said that there is a kwarg __returnFormat__ but it really is __return_format__

https://pymisp.readthedocs.io/modules.html#pymisp.ExpandedPyMISP.search

So I fixed it, if you want here is a PR...

Thanks for your good work, keep it up!
Shorti