### PR TITLE
Fixed __query_virustotal return type

### DIFF
--- a/pymisp/tools/vtreportobject.py
+++ b/pymisp/tools/vtreportobject.py
@@ -81,7 +81,7 @@ class VTReportObject(AbstractMISPObjectGenerator):
             report = requests.get(url, params=params)
         report_json = report.json()
         if report_json["response_code"] == 1:
-            return report
+            return report_json
         else:
             error_msg = "{}: {}".format(resource, report_json["verbose_msg"])
             raise InvalidMISPObject(error_msg)


### PR DESCRIPTION
__query_virustotal returned a Response object and not the json expected; modified so that report_json is returned instead of report.