### PR TITLE
fix: [abstract] Forces file to be read with utf8 encoding

### DIFF
--- a/pymisp/abstract.py
+++ b/pymisp/abstract.py
@@ -46,7 +46,7 @@ class MISPFileCache(object):
     def _load_json(path: Path) -> Union[dict, None]:
         if not path.exists():
             return None
-        with path.open('r') as f:
+        with path.open('r', encoding='utf-8') as f:
             if HAS_RAPIDJSON:
                 data = load(f)
             else:


### PR DESCRIPTION
Make PyMISP opens files in utf-8 and not the system default