### PR TITLE
Previously file object was reporting the libmagic description of a file

### DIFF
--- a/pymisp/tools/fileobject.py
+++ b/pymisp/tools/fileobject.py
@@ -68,7 +68,7 @@ class FileObject(AbstractMISPObjectGenerator):
             self.add_attribute('sha512', value=sha512(self.__data).hexdigest())
             self.add_attribute('malware-sample', value=self.__filename, data=self.__pseudofile)
             if HAS_MAGIC:
-                self.add_attribute('mimetype', value=magic.from_buffer(self.__data))
+                self.add_attribute('mimetype', value=magic.from_buffer(self.__data, mime=True))
             if HAS_PYDEEP:
                 self.add_attribute('ssdeep', value=pydeep.hash_buf(self.__data).decode())
 

--- a/tests/test_fileobject.py
+++ b/tests/test_fileobject.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import json
+from pymisp.tools import FileObject
+import pathlib
+
+
+class TestFileObject(unittest.TestCase):
+    def test_mimeType(self):
+        file_object = FileObject(filepath=pathlib.Path(__file__))
+        attributes = json.loads(file_object.to_json())['Attribute']
+        mime = next(attr for attr in attributes if attr['object_relation'] == 'mimetype')
+        # was "Python script, ASCII text executable"
+        self.assertEqual(mime['value'], 'text/x-python')


### PR DESCRIPTION
instead of the mimetype. According to [MISP DataModels](https://www.misp-project.org/datamodels/#types)
```
mime-type: A media type (also MIME type and content type) is a two-part identifier for file formats and format contents transmitted on the Internet
```
more precisely defined in [RFC2045](https://tools.ietf.org/html/rfc2045) and others.

The description returned by libmagic is more useful than the generic mime-type,
but I did not find a place to put the description in the current data model.