### PR TITLE
Remove explicit loglevel checking

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -2309,15 +2309,13 @@ class PyMISP:
 
         try:
             response_json = response.json()
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(response_json)
+            logger.debug(response_json)
             if isinstance(response_json, dict) and response_json.get('response') is not None:
                 # Cleanup.
                 response_json = response_json['response']
             return response_json
         except Exception:
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(response.text)
+            logger.debug(response.text)
             if expect_json:
                 raise PyMISPUnexpectedResponse(f'Unexpected response from server: {response.text}')
             if lenient_response_type and not response.headers['Accept'].startswith('application/json'):
@@ -2344,10 +2342,9 @@ class PyMISP:
                     data = {k: v for k, v in data.items() if v is not None}
                 d = json.dumps(data, default=pymisp_json_default)
 
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(f'{request_type} - {url}')
-            if d is not None:
-                logger.debug(d)
+        logger.debug(f'{request_type} - {url}')
+        if d is not None:
+            logger.debug(d)
 
         if kw_params:
             # CakePHP params in URL
@@ -2365,8 +2362,7 @@ class PyMISP:
                  'Accept': f'application/{output_type}',
                  'content-type': 'application/json',
                  'User-Agent': user_agent})
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(prepped.headers)
+            logger.debug(prepped.headers)
             settings = s.merge_environment_settings(req.url, proxies=self.proxies or {}, stream=None, verify=self.ssl, cert=self.cert)
             return s.send(prepped, timeout=self.timeout, **settings)
 


### PR DESCRIPTION
There shouldn't be any need to check the loglevel before logging the same level. The logger itself will handle this.