### PR TITLE
Issue #619

### DIFF
--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -1632,7 +1632,12 @@ class MISPObjectAttribute(MISPAttribute):
     def from_dict(self, object_relation: str, value: Union[str, int, float], **kwargs):  # type: ignore
         # NOTE: Signature of "from_dict" incompatible with supertype "MISPAttribute"
         self.object_relation = object_relation
-        self.value = value
+        if type(value) is dict:
+            self.value = value["value"]
+            self.first_seen = value["first_seen"]
+            self.last_seen = value["last_seen"]
+        else:
+            self.value = value
         if 'Attribute' in kwargs:
             kwargs = kwargs['Attribute']
         # Initialize the new MISPAttribute


### PR DESCRIPTION
Small code change that allows me to feed in IOCs as attributes to a MISPObject and have the MISPObjectAttribute from_dict() method pick up the first_seen and last_seen timestamps if they are part of the value dictionary. 

[https://pymisp.readthedocs.io/en/latest/modules.html#pymisp.MISPObject.add_attribute](Add an attribute. object_relation is required and the value key is a dictionary with all the keys supported by MISPAttribute)

[https://pymisp.readthedocs.io/en/latest/_modules/pymisp/mispevent.html#MISPAttribute](I see that first_seen and last_seen are part of that)