### PR TITLE
Drop `encoding=` in Python 3.9

### DIFF
--- a/pymisp/abstract.py
+++ b/pymisp/abstract.py
@@ -47,10 +47,7 @@ class MISPFileCache(object):
         if not path.exists():
             return None
         with path.open('r', encoding='utf-8') as f:
-            if HAS_RAPIDJSON:
-                data = load(f)
-            else:
-                data = load(f, encoding='utf-8')
+            data = load(f)
         return data
 
 


### PR DESCRIPTION
json.load() doesn't have encoding= in Python 3.9. Proposed fix. 