### PR TITLE
adding check if "from" is in the "received" header row

### DIFF
--- a/pymisp/tools/emailobject.py
+++ b/pymisp/tools/emailobject.py
@@ -217,6 +217,8 @@ class EMailObject(AbstractMISPObjectGenerator):
         Extract IP addresses from received headers that are not private.
         """
         for received in self.__parser.received:
+            if "from" not in received:
+                continue
             tokens = received["from"].split(" ")
             ip = None
             for token in tokens:


### PR DESCRIPTION
Ran into an email sent through gmail, where one "received" header line didn't have a "from" field, adding simple check to prevent a hard failure