### PR TITLE
new: Add in ability to create/update/delete MISP Event Reports

### DIFF
--- a/pymisp/__init__.py
+++ b/pymisp/__init__.py
@@ -24,7 +24,7 @@ Response (if any):
 try:
     from .exceptions import PyMISPError, NewEventError, NewAttributeError, MissingDependency, NoURL, NoKey, InvalidMISPObject, UnknownMISPObjectTemplate, PyMISPInvalidFormat, MISPServerError, PyMISPNotImplementedYet, PyMISPUnexpectedResponse, PyMISPEmptyResponse  # noqa
     from .abstract import AbstractMISP, MISPEncode, pymisp_json_default, MISPTag, Distribution, ThreatLevel, Analysis  # noqa
-    from .mispevent import MISPEvent, MISPAttribute, MISPObjectReference, MISPObjectAttribute, MISPObject, MISPUser, MISPOrganisation, MISPSighting, MISPLog, MISPShadowAttribute, MISPWarninglist, MISPTaxonomy, MISPNoticelist, MISPObjectTemplate, MISPSharingGroup, MISPRole, MISPServer, MISPFeed, MISPEventDelegation, MISPUserSetting, MISPInbox, MISPEventBlocklist, MISPOrganisationBlocklist # noqa
+    from .mispevent import MISPEvent, MISPAttribute, MISPObjectReference, MISPObjectAttribute, MISPObject, MISPUser, MISPOrganisation, MISPSighting, MISPLog, MISPShadowAttribute, MISPWarninglist, MISPTaxonomy, MISPNoticelist, MISPObjectTemplate, MISPSharingGroup, MISPRole, MISPServer, MISPFeed, MISPEventDelegation, MISPUserSetting, MISPInbox, MISPEventBlocklist, MISPOrganisationBlocklist, MISPEventReport # noqa
     from .tools import AbstractMISPObjectGenerator  # noqa
     from .tools import Neo4j  # noqa
     from .tools import stix  # noqa

--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -460,7 +460,7 @@ class PyMISP:
         er.from_dict(**updated_event_report)
         return er
 
-    def delete_event_report(self, event_report: Union[MISPEventReport, int, str, UUID], hard: bool = False) -> Dict:
+    def delete_event_report(self, event_report: Union[MISPEventReport, int, str, UUID], hard: bool = False, pythonify: bool = False) -> Dict:
         """Delete an event report from a MISP instance
 
         :param event_report: event report to delete
@@ -472,7 +472,12 @@ class PyMISP:
             request_url += "/1"
         r = self._prepare_request('POST', request_url)
         response = self._check_json_response(r)
-        return response
+        if not (self.global_pythonify or pythonify) or 'errors' in response or hard:
+            # Hard will permanently delete, must return JSON
+            return response
+        er = MISPEventReport()
+        er.from_dict(**response)
+        return er
 
     # ## END Event Report ###
 

--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -407,6 +407,24 @@ class PyMISP:
         er.from_dict(**event_report_r)
         return er
 
+    def get_event_reports(self, event_id: Union[int, str],
+                          pythonify: bool = False) -> Union[Dict, List[MISPEventReport]]:
+        """Get event report from a MISP instance that are attached to an event ID
+
+        :param event_id: event id to get the event reports for
+        :param pythonify: Returns a list of PyMISP Objects instead of the plain json output.
+        """
+        r = self._prepare_request('GET', f'eventReports/index/event_id:{event_id}')
+        event_reports = self._check_json_response(r)
+        if not (self.global_pythonify or pythonify) or 'errors' in event_reports:
+            return event_reports
+        to_return = []
+        for event_report in event_reports:
+            er = MISPEventReport()
+            er.from_dict(**event_report)
+            to_return.append(er)
+        return to_return
+
     def add_event_report(self, event: Union[MISPEvent, int, str, UUID], event_report: MISPEventReport, pythonify: bool = False) -> Union[Dict, MISPEventReport]:
         """Add an event report to an existing MISP event
 

--- a/pymisp/exceptions.py
+++ b/pymisp/exceptions.py
@@ -19,6 +19,10 @@ class NewAttributeError(PyMISPError):
     pass
 
 
+class NewEventReportError(PyMISPError):
+    pass
+
+
 class UpdateAttributeError(PyMISPError):
     pass
 

--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -989,7 +989,6 @@ class MISPEventReport(AbstractMISP):
     def from_dict(self, **kwargs):
         if 'EventReport' in kwargs:
             kwargs = kwargs['EventReport']
-        super().from_dict(**kwargs)
 
         self.distribution = kwargs.pop('distribution', None)
         if self.distribution is not None:
@@ -1028,6 +1027,8 @@ class MISPEventReport(AbstractMISP):
                 self.timestamp = datetime.fromtimestamp(int(ts), timezone.utc)
         if kwargs.get('deleted'):
             self.deleted = kwargs.pop('deleted')
+
+        super().from_dict(**kwargs)
 
     def __repr__(self) -> str:
         if hasattr(self, 'name'):
@@ -1374,6 +1375,7 @@ class MISPEvent(AbstractMISP):
         if kwargs.get('SharingGroup'):
             self.SharingGroup = MISPSharingGroup()
             self.SharingGroup.from_dict(**kwargs.pop('SharingGroup'))
+
         super(MISPEvent, self).from_dict(**kwargs)
 
     def to_dict(self) -> Dict:
@@ -1486,6 +1488,7 @@ class MISPEvent(AbstractMISP):
         event_report = MISPEventReport()
         event_report.from_dict(name=name, content=content, **kwargs)
         self.event_reports.append(event_report)
+        self.edited = True
         return event_report
 
     def get_object_by_id(self, object_id: Union[str, int]) -> MISPObject:

--- a/tests/testlive_comprehensive.py
+++ b/tests/testlive_comprehensive.py
@@ -27,7 +27,7 @@ logger = logging.getLogger('pymisp')
 
 
 try:
-    from pymisp import register_user, PyMISP, MISPEvent, MISPOrganisation, MISPUser, Distribution, ThreatLevel, Analysis, MISPObject, MISPAttribute, MISPSighting, MISPShadowAttribute, MISPTag, MISPSharingGroup, MISPFeed, MISPServer, MISPUserSetting, MISPEventBlocklist
+    from pymisp import register_user, PyMISP, MISPEvent, MISPOrganisation, MISPUser, Distribution, ThreatLevel, Analysis, MISPObject, MISPAttribute, MISPSighting, MISPShadowAttribute, MISPTag, MISPSharingGroup, MISPFeed, MISPServer, MISPUserSetting, MISPEventBlocklist, MISPEventReport
     from pymisp.tools import CSVLoader, DomainIPObject, ASNObject, GenericObjectGenerator
     from pymisp.exceptions import MISPServerError
 except ImportError:
@@ -2573,6 +2573,44 @@ class TestComprehensive(unittest.TestCase):
                 self.admin_misp_connector.delete_event_blocklist(ble)
             for blo in to_delete['bl_organisations']:
                 self.admin_misp_connector.delete_organisation_blocklist(blo)
+
+    def test_event_report(self):
+        event = self.create_simple_event()
+        new_event_report = MISPEventReport()
+        new_event_report.name = "Test Event Report"
+        new_event_report.content = "# Example report markdown"
+        new_event_report.distribution = 5  # Inherit
+        try:
+            event = self.user_misp_connector.add_event(event)
+            new_event_report = self.user_misp_connector.add_event_report(event.id, new_event_report)
+            # The event report should be linked by Event ID
+            self.assertEqual(event.id, new_event_report.event_id)
+
+            event = self.user_misp_connector.get_event(event)
+            # The Event Report should be present on the event
+            self.assertEqual(new_event_report.id, event.event_reports[0].id)
+
+            new_event_report.name = "Updated Event Report"
+            new_event_report.content = "Updated content"
+            new_event_report = self.user_misp_connector.update_event_report(new_event_report)
+            # The event report should be updatable
+            self.assertTrue(new_event_report.name == "Updated Event Report")
+            self.assertTrue(new_event_report.content == "Updated content")
+
+            event_reports = self.user_misp_connector.get_event_reports(event.id)
+            # The event report should be requestable by the Event ID
+            self.assertEqual(new_event_report.id, event_reports[0].id)
+
+            new_event_report = self.user_misp_connector.delete_event_report(new_event_report)
+            # The event report should be soft-deletable
+            self.assertTrue(new_event_report.deleted)
+
+            response = self.user_misp_connector.delete_event_report(new_event_report, True)
+            self.assertTrue(response['success'])
+        finally:
+            self.user_misp_connector.delete_event(event)
+            self.user_misp_connector.delete_event_report(new_event_report)
+
 
     @unittest.skip("Internal use only")
     def missing_methods(self):


### PR DESCRIPTION
Now we have Event Reports in MISP, thought it would be a good thing to be able to manage this through PyMISP.

Unfortunately with the current MISP codebase, there are a few limitations:
- The 'hard' delete flag must be passed in the url as `/1` and not as a POSTed JSON.
- This must be managed through the PyMISP func, e.g. `pm.add_event_report` and not through the `MISPEvent` class. MISP doesn't seem to recognise changes to `EventReports` and update accordingly when POSTed in the Event JSON. As such, I have not included a setter prop for the `MISPEvent.event_reports property.`

Does what we're looking for though :)