### PR TITLE
Add in delete function for a MISP Object

### DIFF
--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -750,6 +750,10 @@ class MISPObject(AbstractMISP):
             # Then we have no meta-category, template_uuid, description and template_version
             pass
 
+    def delete(self):
+        """Mark the attribute as deleted (soft delete)"""
+        self.deleted = True
+
     @property
     def disable_validation(self):
         self._strict = False


### PR DESCRIPTION
Noticed that the MISPObject class didn't have a 'delete' function like a MISPAttribute did, this fixes that. Tested on MISP v2.4.137 and successfully soft deletes an object