### PR TITLE
Proofpoint credential error-handling

### DIFF
--- a/examples/proofpoint_tap.py
+++ b/examples/proofpoint_tap.py
@@ -22,7 +22,7 @@ headers = {
 }
 
 responseSiem = requests.request("GET", urlSiem, headers=headers, params=queryString)
-if 'Credentials authentication failed' in str(responseSiem.text):
+if 'Credentials authentication failed' in responseSiem.text:
     print("Credentials invalid, please edit keys.py and try again")
     quit()
 

--- a/examples/proofpoint_tap.py
+++ b/examples/proofpoint_tap.py
@@ -22,6 +22,9 @@ headers = {
 }
 
 responseSiem = requests.request("GET", urlSiem, headers=headers, params=queryString)
+if 'Credentials authentication failed' in str(responseSiem.text):
+    print("Credentials invalid, please edit keys.py and try again")
+    quit()
 
 jsonDataSiem = json.loads(responseSiem.text)
 


### PR DESCRIPTION
Just added the check for bad authentication for Proofpoint.  Without it, it seems to error out for an unrelated reason.  This makes it obvious what the issue is.