### PR TITLE
Fixed Proofpoint TAP Example

### DIFF
--- a/examples/keys.py.sample
+++ b/examples/keys.py.sample
@@ -5,5 +5,5 @@ misp_url = 'https://<your MISP URL>/'
 misp_key = 'Your MISP auth key' # The MISP auth key can be found on the MISP web interface under the automation section
 misp_verifycert = True
 misp_client_cert = ''
-proofpoint_sp = ''  # Service Principal from TAP (https://threatinsight.proofpoint.com/<custID>/settings/connected-applications)
-proofpoint_secret = ''
+proofpoint_sp = '<proofpoint service principal>'  # Service Principal from TAP (https://threatinsight.proofpoint.com/<custID>/settings/connected-applications)
+proofpoint_secret = '<proofpoint secret>'

--- a/examples/keys.py.sample
+++ b/examples/keys.py.sample
@@ -5,7 +5,5 @@ misp_url = 'https://<your MISP URL>/'
 misp_key = 'Your MISP auth key' # The MISP auth key can be found on the MISP web interface under the automation section
 misp_verifycert = True
 misp_client_cert = ''
-misp_orgID = '2' # Org ID to use for ingesting events
-misp_orgUUID = '11111111-2222-3333-4444-555555555555' # Org UUID to use for ingesting events
 proofpoint_sp = ''  # Service Principal from TAP (https://threatinsight.proofpoint.com/<custID>/settings/connected-applications)
 proofpoint_secret = ''

--- a/examples/keys.py.sample
+++ b/examples/keys.py.sample
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-misp_url = 'https:// your MISP URL /'
+misp_url = 'https://<your MISP URL>/'
 misp_key = 'Your MISP auth key' # The MISP auth key can be found on the MISP web interface under the automation section
 misp_verifycert = True
 misp_client_cert = ''

--- a/examples/keys.py.sample
+++ b/examples/keys.py.sample
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-misp_url = 'https://<your MISP URL>/'
+misp_url = 'https:// your MISP URL /'
 misp_key = 'Your MISP auth key' # The MISP auth key can be found on the MISP web interface under the automation section
 misp_verifycert = True
 misp_client_cert = ''
-proofpoint_key = 'Your Proofpoint TAP auth key'
+misp_orgID = '2' # Org ID to use for ingesting events
+misp_orgUUID = '11111111-2222-3333-4444-555555555555' # Org UUID to use for ingesting events
+proofpoint_sp = ''  # Service Principal from TAP (https://threatinsight.proofpoint.com/<custID>/settings/connected-applications)
+proofpoint_secret = ''

--- a/examples/proofpoint_tap.py
+++ b/examples/proofpoint_tap.py
@@ -22,7 +22,7 @@ headers = {
 }
 
 responseSiem = requests.request("GET", urlSiem, headers=headers, params=queryString)
-if 'Credentials authentication failed' in str(responseSiem.text):
+if 'Credentials authentication failed' in responseSiem.text:
     print("Credentials invalid, please edit keys.py and try again")
     quit()
 

--- a/examples/proofpoint_tap.py
+++ b/examples/proofpoint_tap.py
@@ -1,7 +1,7 @@
 import requests
 from requests.auth import HTTPBasicAuth
 import json
-from pymisp import ExpandedPyMISP, MISPEvent, MISPOrganisation
+from pymisp import ExpandedPyMISP, MISPEvent
 from keys import misp_url, misp_key, misp_verifycert, proofpoint_sp, proofpoint_secret
 import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)

--- a/examples/proofpoint_tap.py
+++ b/examples/proofpoint_tap.py
@@ -4,6 +4,10 @@ import json
 from pymisp import ExpandedPyMISP, MISPEvent, MISPOrganisation
 from keys import misp_url, misp_key, misp_verifycert, proofpoint_sp, proofpoint_secret
 
+if proofpoint_secret == '<proofpoint secret>':
+    print('Set the proofpoint_secret in keys.py before running.  Exiting...')
+    quit()
+
 # initialize PyMISP and set url for Panorama
 misp = ExpandedPyMISP(url=misp_url, key=misp_key, ssl=misp_verifycert)
 

--- a/examples/proofpoint_tap.py
+++ b/examples/proofpoint_tap.py
@@ -3,6 +3,8 @@ from requests.auth import HTTPBasicAuth
 import json
 from pymisp import ExpandedPyMISP, MISPEvent, MISPOrganisation
 from keys import misp_url, misp_key, misp_verifycert, proofpoint_sp, proofpoint_secret
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 if proofpoint_secret == '<proofpoint secret>':
     print('Set the proofpoint_secret in keys.py before running.  Exiting...')

--- a/examples/proofpoint_tap.py
+++ b/examples/proofpoint_tap.py
@@ -2,16 +2,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 import json
 from pymisp import ExpandedPyMISP, MISPEvent, MISPOrganisation
-from keys import misp_url, misp_key, misp_verifycert, proofpoint_sp, proofpoint_secret, misp_orgID, misp_orgUUID
-
-################# Edit these #################
-orgID = misp_orgID
-orgUUID = misp_orgUUID
-##############################################
-
-if orgUUID == '11111111-2222-3333-4444-555555555555':
-    print('Please edit the orgID and orgUUID variables in keys.py')
-    quit()
+from keys import misp_url, misp_key, misp_verifycert, proofpoint_sp, proofpoint_secret
 
 # initialize PyMISP and set url for Panorama
 misp = ExpandedPyMISP(url=misp_url, key=misp_key, ssl=misp_verifycert)

--- a/examples/proofpoint_tap.py
+++ b/examples/proofpoint_tap.py
@@ -22,6 +22,9 @@ headers = {
 }
 
 responseSiem = requests.request("GET", urlSiem, headers=headers, params=queryString)
+if 'Credentials authentication failed' in str(responseSiem.text):
+    print("Credentials invalid, please edit keys.py and try again")
+    quit()
 
 jsonDataSiem = json.loads(responseSiem.text)
 


### PR DESCRIPTION
The Proofpoint TAP example was broken.

- The auth to Proofpoint was not using built-in HTTP Basic Auth, and instead was doing it manually in the header
- The org being set was unnecessary as it uses the misp_key's org as the creator org
- Added error-checking for leaving auth tokens blank
- Ignore SSL verification warnings