### PR TITLE
new: `to_dict` method supports `json_format` parameter

### DIFF
--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -528,8 +528,8 @@ class MISPAttribute(AbstractMISP):
 
         super().from_dict(**kwargs)
 
-    def to_dict(self) -> Dict:
-        to_return = super().to_dict()
+    def to_dict(self, json_format: bool = False) -> Dict:
+        to_return = super().to_dict(json_format)
         if self.data:
             to_return['data'] = base64.b64encode(self.data.getvalue()).decode()
         return to_return
@@ -967,10 +967,10 @@ class MISPObject(AbstractMISP):
             to_return.append(a)
         return to_return
 
-    def to_dict(self, strict: bool = False) -> Dict:
+    def to_dict(self, json_format: bool = False, strict: bool = False) -> Dict:
         if strict or self._strict and self._known_template:
             self._validate()
-        return super(MISPObject, self).to_dict()
+        return super(MISPObject, self).to_dict(json_format)
 
     def to_json(self, sort_keys: bool = False, indent: Optional[int] = None, strict: bool = False):
         if strict or self._strict and self._known_template:
@@ -1730,8 +1730,8 @@ class MISPEvent(AbstractMISP):
 
         super(MISPEvent, self).from_dict(**kwargs)
 
-    def to_dict(self) -> Dict:
-        to_return = super().to_dict()
+    def to_dict(self, json_format: bool = False) -> Dict:
+        to_return = super().to_dict(json_format)
 
         if to_return.get('date'):
             if isinstance(self.date, datetime):

--- a/tests/test_mispevent.py
+++ b/tests/test_mispevent.py
@@ -79,6 +79,15 @@ class TestMISPEvent(unittest.TestCase):
             ref_json = json.load(f)
         self.assertEqual(self.mispevent.to_json(sort_keys=True, indent=2), json.dumps(ref_json, sort_keys=True, indent=2))
 
+    def test_to_dict_json_format(self):
+        misp_event = MISPEvent()
+        av_signature_object = MISPObject("av-signature")
+        av_signature_object.add_attribute("signature", "EICAR")
+        av_signature_object.add_attribute("software", "ClamAv")
+        misp_event.add_object(av_signature_object)
+
+        self.assertEqual(json.loads(misp_event.to_json()), misp_event.to_dict(json_format=True))
+
     def test_object_tag(self):
         self.mispevent.add_object(name='file', strict=True)
         a = self.mispevent.objects[0].add_attribute('filename', value='')


### PR DESCRIPTION
This call replaces calling `json.loads(misp_event.to_json())` that is super inefficient.