### PR TITLE
Fix #787 and add Unicode to ASCII function

### DIFF
--- a/pymisp/tools/emailobject.py
+++ b/pymisp/tools/emailobject.py
@@ -251,16 +251,6 @@ class EMailObject(AbstractMISPObjectGenerator):
             pass
         return to_return
 
-    def unicode_to_ascii(self, arg):
-        """
-        This function removes unicode characters and returns an ASCII string.
-        Spam messages commonly contain unicode encoded emojis which MISP cannot
-        handle. Those would either cause an error or show up as "?" in the UI.
-        """
-        string_encode = arg.encode("ascii", "ignore")
-        string_decode = string_encode.decode()
-        return string_decode
-
     def generate_attributes(self):
 
         # Attach original & Converted
@@ -296,8 +286,7 @@ class EMailObject(AbstractMISPObjectGenerator):
             self.__add_emails("to", message["Delivered-To"])
 
         if "From" in message:
-            from_ascii = self.unicode_to_ascii(message["From"])
-            self.__add_emails("from", from_ascii)
+            self.__add_emails("from", message["From"])
 
         if "Return-Path" in message:
             realname, address = email.utils.parseaddr(message["Return-Path"])
@@ -310,8 +299,7 @@ class EMailObject(AbstractMISPObjectGenerator):
             self.__add_emails("cc", message["Cc"])
 
         if "Subject" in message:
-            subject_ascii = self.unicode_to_ascii(message["Subject"])
-            self.add_attribute("subject", subject_ascii)
+            self.add_attribute("subject", message["Subject"])
 
         if "Message-ID" in message:
             self.add_attribute("message-id", message["Message-ID"])


### PR DESCRIPTION
Fix #787
- Uses regex to pick up the hostnames/domains from the "Received: from" headers.

Unicode to ASCII function
- Spam messages more often than not contain junk text as unicode characters in the headers. The "from" and "subject" headers being the most common ones. Before this change the script would error on such emails or sometimes replace the unicode characters with questionmarks "?".
- Function takes argument as an input and then encodes it in ascii while ignoring any malformed data. It then returns an ASCII string without the unicode characters.
- Currently implemented for "from" and "subject" handling.