### PR TITLE
Improve sharing groups, new get_sharing_group and return sharing group orgs

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -1921,6 +1921,21 @@ class PyMISP:
             to_return.append(s)
         return to_return
 
+    def get_sharing_group(self, sharing_group: Union[MISPSharingGroup, int, str, UUID], pythonify: bool = False) -> Union[Dict, MISPSharingGroup]:
+        """Get a sharing group
+
+        :param sharing_group: sharing group to find
+        :param pythonify: Returns a PyMISP Object instead of the plain json output
+        """
+        sharing_group_id = get_uuid_or_id_from_abstract_misp(sharing_group)
+        r = self._prepare_request('GET', f'sharing_groups/view/{sharing_group_id}')
+        sharing_group = self._check_json_response(r)
+        if not (self.global_pythonify or pythonify) or 'errors' in sharing_group:
+            return sharing_group
+        s = MISPSharingGroup()
+        s.from_dict(**sharing_group)
+        return s
+
     def add_sharing_group(self, sharing_group: MISPSharingGroup, pythonify: bool = False) -> Union[Dict, MISPSharingGroup]:
         """Add a new sharing group
 

--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -126,11 +126,39 @@ class MISPOrganisation(AbstractMISP):
 
 
 class MISPSharingGroup(AbstractMISP):
+    def __init__(self):
+        super().__init__()
+        self.SharingGroupOrg: List[MISPOrganisation] = []
+
+    @property
+    def orgs(self) -> List[MISPOrganisation]:
+        return self.SharingGroupOrg
+
+    @orgs.setter
+    def orgs(self, orgs: List[MISPOrganisation]):
+        """Set a list of prepared MISPSighting."""
+        if all(isinstance(x, MISPSighting) for x in orgs):
+            self.SharingGroupOrg = orgs
+        else:
+            raise PyMISPError('All the attributes have to be of type MISPOrganisation.')
+
+    def add_org(self, org):
+        misp_org = MISPOrganisation()
+        misp_org.from_dict(**org)
+        self.SharingGroupOrg.append(misp_org)
+        return misp_org
 
     def from_dict(self, **kwargs):
+        if 'SharingGroupOrg' in kwargs:
+            [self.add_org(org) for org in kwargs.pop('SharingGroupOrg')]
         if 'SharingGroup' in kwargs:
             kwargs = kwargs['SharingGroup']
         super().from_dict(**kwargs)
+
+    def __repr__(self) -> str:
+        if hasattr(self, 'name'):
+            return f'<{self.__class__.__name__}(name={self.name})'
+        return f'<{self.__class__.__name__}(NotInitialized)'
 
 
 class MISPShadowAttribute(AbstractMISP):


### PR DESCRIPTION
This PR allows you to query for a specific sharing group with a new function of `get_sharing_group`, and also returns the list of organisations included in a sharing group by default.

The 2nd one is the most important, as when pythonified, you can't enumerate the sharing groups an organisation is part of, or the orgs part of a sharing group