### PR TITLE
fix: change returnFormat to return_format.

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -2484,9 +2484,9 @@ class PyMISP:
         if return_format not in return_formats:
             raise ValueError('return_format has to be in {}'.format(', '.join(return_formats)))
         if return_format == 'stix-xml':
-            query['returnFormat'] = 'stix'
+            query['return_format'] = 'stix'
         else:
-            query['returnFormat'] = return_format
+            query['return_format'] = return_format
 
         query['page'] = page
         query['limit'] = limit


### PR DESCRIPTION
According to the openAPI documentation `returnFormat` should be use while actually it should be `return_format`.

```
$ curl -X POST -d '{"returnFormat":"stix2"}' "${HEADERS[@]}" $URL$URI
Error while processing your query:

$ curl -X POST -d '{"return_format":"stix2"}' "${HEADERS[@]}" $URL$URI
{"response": [{"Event":{
[...]
```