### PR TITLE
Feature feedgenerator exclude malwares

### DIFF
--- a/examples/feed-generator/generate.py
+++ b/examples/feed-generator/generate.py
@@ -62,7 +62,7 @@ def saveManifest(manifest):
 if __name__ == '__main__':
     misp = init()
     try:
-        events = misp.search(metadata=True, limit=entries, **filters, pythonify=True)
+        events = misp.search_index(minimal=True, limit=entries, **filters, pythonify=False)
     except Exception as e:
         print(e)
         sys.exit("Invalid response received from MISP.")

--- a/examples/feed-generator/generate.py
+++ b/examples/feed-generator/generate.py
@@ -12,6 +12,11 @@ try:
 except ImportError:
     include_deleted = False
 
+try:
+    from settings import exclude_malware_samples
+except ImportError:
+    exclude_malware_samples = False
+
 valid_attribute_distributions = []
 
 
@@ -70,9 +75,13 @@ if __name__ == '__main__':
     for event in events:
         try:
             e = misp.get_event(event.uuid, deleted=include_deleted, pythonify=True)
+            if exclude_malware_samples:
+                for i, attribute in enumerate(e.attributes):
+                    if attribute.type == 'malware-sample':
+                        del e.attributes[i]
             e_feed = e.to_feed(valid_distributions=valid_attribute_distributions, with_meta=True)
-        except Exception as e:
-            print(e, event.uuid)
+        except Exception as err:
+            print(err, event.uuid)
             continue
         if not e_feed:
             print(f'Invalid distribution {e.distribution}, skipping')

--- a/examples/feed-generator/settings.default.py
+++ b/examples/feed-generator/settings.default.py
@@ -12,9 +12,6 @@ ssl = False
 # sure that you use a directory dedicated to the feed
 outputdir = 'output'
 
-# Determine the number of entries to output
-entries = 200
-
 # The filters to be used for by the feed. You can use any filter that
 # you can use on the event index, such as organisation, tags, etc.
 # It uses the same joining and condition rules as the API parameters
@@ -42,9 +39,10 @@ include_deleted = False
 # 5: Inherit Event
 valid_attribute_distribution_levels = ['0', '1', '2', '3', '4', '5']
 
-
 # By default, all attribute passing the filtering rules will be exported.
-# This setting can be used to filter out attributes being of the type `malaware-sample`. 
+# This setting can be used to filter out any attributes being of the type contained in the list. 
 # Warning: Keep in mind that if you propagate data (via synchronisation/feeds/...), recipients
-# will not be able to get the malware samples back.
-exclude_malware_samples = False
+# will not be able to get these attributes back unless their events get updated.
+# For example:
+# exclude_attribute_types = ['malware-sample']
+exclude_attribute_types = []

--- a/examples/feed-generator/settings.default.py
+++ b/examples/feed-generator/settings.default.py
@@ -42,3 +42,9 @@ include_deleted = False
 # 5: Inherit Event
 valid_attribute_distribution_levels = ['0', '1', '2', '3', '4', '5']
 
+
+# By default, all attribute passing the filtering rules will be exported.
+# This setting can be used to filter out attributes being of the type `malaware-sample`. 
+# Warning: Keep in mind that if you propagate data (via synchronisation/feeds/...), recipients
+# will not be able to get the malware samples back.
+exclude_malware_samples = False


### PR DESCRIPTION
- Revert back the event initial search to use the index endpoint instead of RestSearch
    - Relying on RestSearch was offering more flexibility than index in terms of filtering options, however, it might introduce a significant overhead potentially leading to timeout for some server.
- Add a means to filter out specified attribute types