### PR TITLE
chg: [feed-generator] support for distribution and sharing groups

### DIFF
--- a/examples/feed-generator/generate.py
+++ b/examples/feed-generator/generate.py
@@ -8,7 +8,7 @@ from pymisp import ExpandedPyMISP
 from settings import url, key, ssl, outputdir, filters, valid_attribute_distribution_levels
 try:
     from settings import with_distribution
-except:
+except ImportError:
     with_distribution = False
 
 try:

--- a/examples/feed-generator/generate.py
+++ b/examples/feed-generator/generate.py
@@ -6,6 +6,10 @@ import json
 import os
 from pymisp import ExpandedPyMISP
 from settings import url, key, ssl, outputdir, filters, valid_attribute_distribution_levels
+try:
+    from settings import with_distribution
+except:
+    with_distribution = False
 
 try:
     from settings import include_deleted
@@ -79,7 +83,7 @@ if __name__ == '__main__':
                 for i, attribute in enumerate(e.attributes):
                     if attribute.type in exclude_attribute_types:
                         e.attributes.pop(i)
-            e_feed = e.to_feed(valid_distributions=valid_attribute_distributions, with_meta=True)
+            e_feed = e.to_feed(valid_distributions=valid_attribute_distributions, with_meta=True, with_distribution=with_distribution)
         except Exception as err:
             print(err, event['uuid'])
             continue

--- a/examples/feed-generator/settings.default.py
+++ b/examples/feed-generator/settings.default.py
@@ -46,3 +46,8 @@ valid_attribute_distribution_levels = ['0', '1', '2', '3', '4', '5']
 # For example:
 # exclude_attribute_types = ['malware-sample']
 exclude_attribute_types = []
+
+# Include the distribution and sharing group information (and names/UUIDs of organisations in those Sharing Groups)
+# Set this to False if you want to discard the distribution metadata. That way all data will inherit the distribution
+# the feed
+with_distribution = False

--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -174,6 +174,7 @@ class MISPSharingGroup(AbstractMISP):
             server['Server'].pop('id', None)
         return to_return
 
+
 class MISPShadowAttribute(AbstractMISP):
 
     def __init__(self):
@@ -344,7 +345,7 @@ class MISPAttribute(AbstractMISP):
         if not hasattr(self, 'timestamp'):
             self.timestamp = datetime.timestamp(datetime.now())
 
-    def _to_feed(self, with_distribution = False) -> Dict:
+    def _to_feed(self, with_distribution=False) -> Dict:
         if with_distribution:
             self._fields_for_feed.add('distribution')
         to_return = super()._to_feed()
@@ -763,7 +764,7 @@ class MISPObject(AbstractMISP):
         if not hasattr(self, 'timestamp'):
             self.timestamp = datetime.timestamp(datetime.now())
 
-    def _to_feed(self, with_distribution = False) -> Dict:
+    def _to_feed(self, with_distribution=False) -> Dict:
         if with_distribution:
             self._fields_for_feed.add('distribution')
         to_return = super(MISPObject, self)._to_feed()
@@ -1531,7 +1532,7 @@ class MISPEvent(AbstractMISP):
                 to_return += attribute.hash_values(algorithm)
         return to_return
 
-    def to_feed(self, valid_distributions: List[int] = [0, 1, 2, 3, 4, 5], with_meta: bool = False, with_distribution = False) -> Dict:
+    def to_feed(self, valid_distributions: List[int] = [0, 1, 2, 3, 4, 5], with_meta: bool = False, with_distribution=False) -> Dict:
         """ Generate a json output for MISP Feed.
 
         :param valid_distributions: only makes sense if the distribution key is set; i.e., the event is exported from a MISP instance.

--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -344,7 +344,7 @@ class MISPAttribute(AbstractMISP):
         if not hasattr(self, 'timestamp'):
             self.timestamp = datetime.timestamp(datetime.now())
 
-    def _to_feed(self, with_distribution = True) -> Dict:
+    def _to_feed(self, with_distribution = False) -> Dict:
         if with_distribution:
             self._fields_for_feed.add('distribution')
         to_return = super()._to_feed()
@@ -763,7 +763,7 @@ class MISPObject(AbstractMISP):
         if not hasattr(self, 'timestamp'):
             self.timestamp = datetime.timestamp(datetime.now())
 
-    def _to_feed(self, with_distribution = True) -> Dict:
+    def _to_feed(self, with_distribution = False) -> Dict:
         if with_distribution:
             self._fields_for_feed.add('distribution')
         to_return = super(MISPObject, self)._to_feed()
@@ -1531,7 +1531,7 @@ class MISPEvent(AbstractMISP):
                 to_return += attribute.hash_values(algorithm)
         return to_return
 
-    def to_feed(self, valid_distributions: List[int] = [0, 1, 2, 3, 4, 5], with_meta: bool = False, with_distribution = True) -> Dict:
+    def to_feed(self, valid_distributions: List[int] = [0, 1, 2, 3, 4, 5], with_meta: bool = False, with_distribution = False) -> Dict:
         """ Generate a json output for MISP Feed.
 
         :param valid_distributions: only makes sense if the distribution key is set; i.e., the event is exported from a MISP instance.


### PR DESCRIPTION
This PR brings in the option to export the feed with distribution and Sharing Group information.
This is one of the requirements to fully support distribution/sharing groups in the Feed system, see https://github.com/MISP/MISP/issues/5758