### PR TITLE
Add feed option for local tag exclusion

### DIFF
--- a/examples/feed-generator/generate.py
+++ b/examples/feed-generator/generate.py
@@ -12,6 +12,11 @@ except ImportError:
     with_distribution = False
 
 try:
+    from settings import with_local_tags
+except ImportError:
+    with_local_tags = True
+
+try:
     from settings import include_deleted
 except ImportError:
     include_deleted = False
@@ -83,7 +88,7 @@ if __name__ == '__main__':
                 for i, attribute in enumerate(e.attributes):
                     if attribute.type in exclude_attribute_types:
                         e.attributes.pop(i)
-            e_feed = e.to_feed(valid_distributions=valid_attribute_distributions, with_meta=True, with_distribution=with_distribution)
+            e_feed = e.to_feed(valid_distributions=valid_attribute_distributions, with_meta=True, with_distribution=with_distribution, with_local_tags=with_local_tags)
         except Exception as err:
             print(err, event['uuid'])
             continue

--- a/examples/feed-generator/settings.default.py
+++ b/examples/feed-generator/settings.default.py
@@ -51,3 +51,6 @@ exclude_attribute_types = []
 # Set this to False if you want to discard the distribution metadata. That way all data will inherit the distribution
 # the feed
 with_distribution = False
+
+# Include the exportable local tags along with the global tags.  The default is True.
+with_local_tags = True

--- a/pymisp/abstract.py
+++ b/pymisp/abstract.py
@@ -365,6 +365,7 @@ class MISPTag(AbstractMISP):
         super().__init__(**kwargs)
         self.name: str
         self.exportable: bool
+        self.local: bool
 
     def from_dict(self, **kwargs):
         if kwargs.get('Tag'):
@@ -375,8 +376,10 @@ class MISPTag(AbstractMISP):
         if not hasattr(self, 'colour'):
             self.colour = '#ffffff'
 
-    def _to_feed(self) -> Dict:
+    def _to_feed(self, with_local: bool = True) -> Dict:
         if hasattr(self, 'exportable') and not self.exportable:
+            return {}
+        if with_local is False and hasattr(self, 'local') and self.local:
             return {}
         return super()._to_feed()
 

--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -1558,11 +1558,12 @@ class MISPEvent(AbstractMISP):
                 to_return += attribute.hash_values(algorithm)
         return to_return
 
-    def to_feed(self, valid_distributions: List[int] = [0, 1, 2, 3, 4, 5], with_meta: bool = False, with_distribution=False) -> Dict:
+    def to_feed(self, valid_distributions: List[int] = [0, 1, 2, 3, 4, 5], with_meta: bool = False, with_distribution=False, with_local_tags: bool = True) -> Dict:
         """ Generate a json output for MISP Feed.
 
         :param valid_distributions: only makes sense if the distribution key is set; i.e., the event is exported from a MISP instance.
         :param with_distribution: exports distribution and Sharing Group info; otherwise all SharingGroup information is discarded (protecting privacy)
+        :param with_local_tags: tag export includes local exportable tags along with global exportable tags
         """
         required = ['info', 'Orgc']
         for r in required:
@@ -1583,7 +1584,7 @@ class MISPEvent(AbstractMISP):
             to_return['_manifest'] = self.manifest
 
         to_return['Orgc'] = self.Orgc._to_feed()
-        to_return['Tag'] = list(filter(None, [tag._to_feed() for tag in self.tags]))
+        to_return['Tag'] = list(filter(None, [tag._to_feed(with_local_tags) for tag in self.tags]))
         if self.attributes:
             to_return['Attribute'] = []
             for attribute in self.attributes:


### PR DESCRIPTION
This adds the parameter `with_local_tags` to the MISPEvent `to_feed()` function, which allows you to exclude your local tags from the feed export.  Since I'll be sharing the feed, local tags is not something I want to include.  However, I did set the default to `True`, since that is the current behavior.

Code includes an update to the `feed-generator` example.