### PR TITLE
Fix: Make mispevent.py FIPS Compliant

### DIFF
--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -1592,7 +1592,7 @@ class MISPEvent(AbstractMISP):
                     continue
                 to_return['Attribute'].append(attribute._to_feed(with_distribution=with_distribution))
                 if with_meta:
-                    to_return['_hashes'] += attribute.hash_values('md5')
+                    to_return['_hashes'] += attribute.hash_values('sha1')
 
         if self.objects:
             to_return['Object'] = []
@@ -1608,7 +1608,7 @@ class MISPEvent(AbstractMISP):
                         continue
                     obj_to_attach['Attribute'].append(attribute._to_feed(with_distribution=with_distribution))
                     if with_meta:
-                        to_return['_hashes'] += attribute.hash_values('md5')
+                        to_return['_hashes'] += attribute.hash_values('sha1')
                 to_return['Object'].append(obj_to_attach)
 
         if with_distribution:


### PR DESCRIPTION
trying to return an md5 on a RHEL or CentOS box that is set to fips=1 will produce the following error when exporting events using the feed-generator script.
```
[digital envelope routines: EVP_DigestInit_ex] disabled for fips 5d727604-2d54-48f4-a0c1-10bc0bc8150b
[digital envelope routines: EVP_DigestInit_ex] disabled for fips 5c570cda-4174-4fbc-87ee-35c30bc81515
[digital envelope routines: EVP_DigestInit_ex] disabled for fips 5cdd7b75-e16c-4893-af42-72ae0bc8150b
```
By returning a FIPS compliant algorithm instead like sha1 the feed-generator works as expected.  There are other areas in PyMISP that also might contain errors on a FIPS compliant system. I took an event and it imported just fine into a misp instance (after changing the uuid so it wasn't a duplicate). 

Is this ok, or was there another ready to use md5 instead of sha1 (or stronger).