### PR TITLE
fix: [feed] fixes bug when template_uuid does not exist

### DIFF
--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -793,9 +793,12 @@ class MISPObject(AbstractMISP):
     def _to_feed(self, with_distribution=False) -> Dict:
         if with_distribution:
             self._fields_for_feed.add('distribution')
-        if not hasattr(self, 'template_uuid'):
-            # workaround for old events where the template_uuid was not yet mandatory
-            self.template_uuid = '11111111-1111-1111-aaaa-111111111111'
+        if not hasattr(self, 'template_uuid'):  # workaround for old events where the template_uuid was not yet mandatory
+            self.template_uuid = str(uuid.uuid5(uuid.UUID("9319371e-2504-4128-8410-3741cebbcfd3"), self.name))
+        if not hasattr(self, 'description'):    # workaround for old events where description is not always set
+            self.description='<unknown>'
+        if not hasattr(self, 'meta-category'):  # workaround for old events where meta-category is not always set
+            setattr(self, 'meta-category', 'misc')
         to_return = super(MISPObject, self)._to_feed()
         if self.references:
             to_return['ObjectReference'] = [reference._to_feed() for reference in self.references]

--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -793,6 +793,9 @@ class MISPObject(AbstractMISP):
     def _to_feed(self, with_distribution=False) -> Dict:
         if with_distribution:
             self._fields_for_feed.add('distribution')
+        if not hasattr(self, 'template_uuid'):
+            # workaround for old events where the template_uuid was not yet mandatory
+            self.template_uuid = '11111111-1111-1111-aaaa-111111111111'
         to_return = super(MISPObject, self)._to_feed()
         if self.references:
             to_return['ObjectReference'] = [reference._to_feed() for reference in self.references]


### PR DESCRIPTION
In some cases, due to historical reasons, MISP objects might not contain a `template_uuid`. 
When this happens the MISP feed exporter complains and does not export the event.
Current MISP versions require a present template uuid when importing events, so exporting an empty uuid is not an option. The proposal to address this is by using a hardcoded uuid, that is obviously non-random. Objects exported this way will therefore be correctly imported by MISP, and remain non-editable.

Note1: impact on MISP: none. A fake uuid results in objects not being editable, which would also have been the case if the uuid was absent.
Note2: a few numbers are `aaaa`, this is because cakephp refuses to accept an uuid with only `1`. 