### PR TITLE
Add in ability to set a taxonomies required status

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -1191,6 +1191,17 @@ class PyMISP:
         response = self._prepare_request('POST', 'taxonomies/update')
         return self._check_json_response(response)
 
+    def set_taxonomy_required(self, taxonomy: Union[MISPTaxonomy, int, str], required: bool = False) -> Dict:
+        taxonomy_id = get_uuid_or_id_from_abstract_misp(taxonomy)
+        url = urljoin(self.root_url, 'taxonomies/toggleRequired/{}'.format(taxonomy_id))
+        payload = {
+            "Taxonomy": {
+                "required": required
+            }
+        }
+        response = self._prepare_request('POST', url, data=payload)
+        return self._check_json_response(response)
+
     # ## END Taxonomies ###
 
     # ## BEGIN Warninglists ###

--- a/tests/testlive_comprehensive.py
+++ b/tests/testlive_comprehensive.py
@@ -1657,6 +1657,16 @@ class TestComprehensive(unittest.TestCase):
         r = self.admin_misp_connector.disable_taxonomy(tax)
         self.assertEqual(r['message'], 'Taxonomy disabled')
 
+        # Test toggling the required status
+        r = self.admin_misp_connector.set_taxonomy_required(tax, not tax.required)
+        self.assertEqual(r['message'], 'Taxonomy toggleRequireded')
+
+        updatedTax = self.admin_misp_connector.get_taxonomy(tax, pythonify=True)
+        self.assertFalse(tax.required == updatedTax.required)
+
+        # Return back to default required status
+        r = self.admin_misp_connector.set_taxonomy_required(tax, not tax.required)
+
     def test_warninglists(self):
         # Make sure we're up-to-date
         r = self.admin_misp_connector.update_warninglists()


### PR DESCRIPTION
This PR adds in the functionality to set a taxonomies required status as per #831. Turns out the toggle isn't really a toggle on MISP's API and you in fact provide the `required` parameter in the request.

Tested locally and can confirm it appropriately sets the `required` value of the respective taxonomy