### PR TITLE
Update __init__.py

### DIFF
--- a/pymisp/__init__.py
+++ b/pymisp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.4.162.1'
+__version__ = '2.4.165'
 import logging
 import sys
 import warnings


### PR DESCRIPTION
Regardless of running the latest PyMISP version, the message below is presented:
```
The version of PyMISP recommended by the MISP instance (2.4.165) is newer than the one you're using now (2.4.162.1). Please upgrade PyMISP.
```