### PR TITLE
fix: Correct FileObject import

### DIFF
--- a/pymisp/tools/create_misp_object.py
+++ b/pymisp/tools/create_misp_object.py
@@ -8,6 +8,7 @@ from io import BytesIO
 from typing import Any, TYPE_CHECKING
 
 from ..exceptions import MISPObjectException
+from . import FileObject
 logger = logging.getLogger('pymisp')
 
 try:
@@ -19,8 +20,6 @@ try:
     from .peobject import make_pe_objects
     from .elfobject import make_elf_objects
     from .machoobject import make_macho_objects
-    from . import FileObject
-
 except AttributeError:
     HAS_LIEF = False
     logger.critical('You need lief >= 0.11.0. The quick and dirty fix is: pip3 install --force pymisp[fileobjects]')


### PR DESCRIPTION
Commit 9853f23 erroneously moved the import of `FileObject` in `pymisp/tools/create_misp_object.py` to the `TYPE_CHECKING` conditional. This was later changed by 8fb34a2, however, the commit moved the import inside the try-except-block related to `lief`. As a consequence `FileObject` is not imported if `lief` is not available, but it is needed regardless, resulting in confusing exceptions unrelated to `lief`:

```
Traceback (most recent call last):
  File "/home/user/test.py", line 16, in <module>
    event.run_expansions()
  File "/home/user/.venv/lib/python3.10/site-packages/pymisp/mispevent.py", line 2029, in run_expansions
    file_object, bin_type_object, bin_section_objects = make_binary_objects(pseudofile=attribute.malware_binary, filename=attribute.malware_filename)
  File "/home/user/.venv/lib/python3.10/site-packages/pymisp/tools/create_misp_object.py", line 44, in make_binary_objects
    misp_file = FileObject(filepath=filepath, pseudofile=pseudofile, filename=filename,
NameError: name 'FileObject' is not defined
```

This pull request moves the import of `FileObject` outside the try-except block where it was before 9853f23.