### PR TITLE
Fix SSL verification in PyMISP by adding `verify` parameter to requests.get in pymisp_version_main and misp_instance_version_master

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -300,7 +300,7 @@ class PyMISP:
     @property
     def pymisp_version_main(self) -> dict[str, Any] | list[dict[str, Any]]:
         """Get the most recent version of PyMISP from github"""
-        r = requests.get('https://raw.githubusercontent.com/MISP/PyMISP/main/pyproject.toml')
+        r = requests.get('https://raw.githubusercontent.com/MISP/PyMISP/main/pyproject.toml', verify=self.ssl)
         if r.status_code == 200:
             version = re.findall('version = "(.*)"', r.text)
             return {'version': version[0]}
@@ -315,7 +315,7 @@ class PyMISP:
     @property
     def misp_instance_version_master(self) -> dict[str, Any] | list[dict[str, Any]]:
         """Get the most recent version from github"""
-        r = requests.get('https://raw.githubusercontent.com/MISP/MISP/2.4/VERSION.json')
+        r = requests.get('https://raw.githubusercontent.com/MISP/MISP/2.4/VERSION.json', verify=self.ssl)
         if r.status_code == 200:
             master_version = loads(r.content)
             return {'version': '{}.{}.{}'.format(master_version['major'], master_version['minor'], master_version['hotfix'])}


### PR DESCRIPTION
### Summary
I have made modifications to the `pymisp_version_main` and `misp_instance_version_master` methods in PyMISP to include the `verify=self.ssl` parameter in the `requests.get` calls.

### Issue
The following code triggered an SSL certificate verification error in my environment:

```python
>>> misp = PyMISP(MISP_URL, MISP_AUTHKEY, ssl=False)                                                                    
>>> misp.pymisp_version_main
```

This resulted in the following error trace:

```plaintext
Traceback (most recent call last):                                                                                      
  File "/home/mitsukawa/.local/lib/python3.10/site-packages/urllib3/connectionpool.py", line 467, in _make_request      
    self._validate_conn(conn)                                                                                           
  File "/home/mitsukawa/.local/lib/python3.10/site-packages/urllib3/connectionpool.py", line 1099, in _validate_conn    
    conn.connect()                                                                                                      
  File "/home/mitsukawa/.local/lib/python3.10/site-packages/urllib3/connection.py", line 653, in connect                
    sock_and_verified = _ssl_wrap_socket_and match_hostname(                                                            
  File "/home/mitsukawa/.local/lib/python3.10/site-packages/urllib3/connection.py", line 806, in _ssl_wrap_socket_and match_hostname                                                                                                            
    ssl_sock = ssl_wrap_socket(                                                                                         
  File "/home/mitsukawa/.local/lib/python3.10/site-packages/urllib3/util/ssl_.py", line 465, in ssl_wrap_socket         
    ssl_sock = _ssl_wrap_socket_impl(sock, context, tls_in_tls, server_hostname)                                        
  File "/home/mitsukawa/.local/lib/python3.10/site-packages/urllib3/util/ssl_.py", line 509, in _ssl_wrap_socket_impl   
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)                                               
  File "/usr/lib/python3.10/ssl.py", line 513, in wrap_socket                                                           
    return self.sslsocket_class._create(                                                                                
  File "/usr/lib/python3.10/ssl.py", line 1100, in _create                                                              
    self.do_handshake()                                                                                                 
  File "/usr/lib/python3.10/ssl.py", line 1371, in do_handshake                                                         
    self._sslobj.do_handshake()                                                                                         
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1007)
```

A similar error occurred when executing the `misp_instance_version_master` method.

### Solution
To address this issue, I have added the `verify=self.ssl` parameter to the `requests.get` calls within these methods. This allows the SSL verification setting to be controlled based on the user's configuration, avoiding the certificate verification errors in environments with self-signed certificates or other SSL-related configurations.

### Testing
These changes have been tested in my environment, where the previous SSL errors were occurring, and the issue has been resolved.
