### PR TITLE
fix: [search_index] Update date_from and date_to parameters to date str

### DIFF
--- a/tests/testlive_comprehensive.py
+++ b/tests/testlive_comprehensive.py
@@ -344,6 +344,32 @@ class TestComprehensive(unittest.TestCase):
             # *First*|Second|Third event
             event = self.admin_misp_connector.search_index(timestamp=ts, sort="info", desc=False, limit=1, pythonify=True)[0]  # type: ignore[index,assignment]
             self.assertEqual(event.id, first.id)
+
+            # Test date_from (which in turn proves date_to)
+            # Represented as date
+            event: MISPEvent = self.admin_misp_connector.search_index(
+                date_from=first.date,
+                eventinfo=first.info, limit=1, pythonify=True
+            )[0]
+            self.assertEqual(event.id, first.id)
+            # Represented as timestamp
+            event: MISPEvent = self.admin_misp_connector.search_index(
+                date_from=datetime.combine(first.date, datetime.min.time()).timestamp(),
+                eventinfo=first.info, limit=1, pythonify=True
+            )[0]
+            self.assertEqual(event.id, first.id)
+            # Represented as string
+            event: MISPEvent = self.admin_misp_connector.search_index(
+                date_from=first.date.strftime("%Y-%m-%d"),
+                eventinfo=first.info, limit=1, pythonify=True
+            )[0]
+            self.assertEqual(event.id, first.id)
+            # Check it actually works (increase date to lose match)
+            no_events = self.admin_misp_connector.search_index(
+                date_from=first.date + timedelta(days=1),
+                eventinfo=first.info, limit=1, pythonify=True
+            )
+            self.assertTrue(len(no_events) == 0)
         finally:
             # Delete event
             self.admin_misp_connector.delete_event(first)


### PR DESCRIPTION
I don't think it was always this way, but it now appears that MISP is unable to handle the `datefrom` and `dateto` parameters for the event index as timestamps. The value is directly passed to the DB, which has unexpected results depending on the DB choice:
- MariaDB: Seems to return everything, ignoring the filter
- Azure MySQL: Returns nothing 

The solution is to instead format the field as a date string `YYYY-MM-DD` which correctly enables you to use these filters on the `search_index` endpoint. This should be a non-breaking change, as the fields accept the same input types as before.