### PR TITLE
Add a check if MISPObject.add_attributes() method has truly values to add

### DIFF
--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -1121,6 +1121,11 @@ class MISPObject(AnalystDataBehaviorMixin):
         It is the same as calling multiple times add_attribute with the same object_relation.
         '''
         to_return = []
+
+        if not attributes:
+            logger.warning(f"The attributes you're trying to add have no value, skipping it. Object relation: {object_relation}")
+            return to_return
+
         for attribute in attributes:
             if isinstance(attribute, MISPAttribute):
                 a = self.add_attribute(object_relation, **attribute.to_dict())

--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -1123,7 +1123,7 @@ class MISPObject(AnalystDataBehaviorMixin):
         to_return = []
 
         if not attributes:
-            logger.warning(f"The attributes you're trying to add have no value, skipping it. Object relation: {object_relation}")
+            logger.warning(f"No attributes provided for object relation '{object_relation}'; skipping attribute addition.")
             return to_return
 
         for attribute in attributes:


### PR DESCRIPTION
At the moment, the signature of the method allows the passing of an unpacked list that is empty and the loop is simply skipped with no feedback.

To make the behaviour more aligned to the [add_attribute](https://github.com/MISP/PyMISP/blob/b0632cca12f8f75e7af22d84591163f69f7b1579/pymisp/mispevent.py#L1083) method, I would suggest adding a check and an informative warning in the case this happens.