### PR TITLE
replace deprecated ExpandedPyMISP with PyMISP

### DIFF
--- a/examples/add_attributes_from_csv.py
+++ b/examples/add_attributes_from_csv.py
@@ -3,7 +3,7 @@
 
 import csv
 from pymisp import PyMISP
-from pymisp import ExpandedPyMISP, MISPAttribute
+from pymisp import PyMISP, MISPAttribute
 from keys import misp_url, misp_key, misp_verifycert
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 import argparse
@@ -42,7 +42,7 @@ if __name__ == '__main__':
     parser.add_argument("-f", "--attr_file", required=True, help="Attribute CSV file path")
     args = parser.parse_args()
 
-    pymisp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    pymisp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     f = open(args.attr_file, newline='')
     csv_reader = csv.reader(f, delimiter=";")

--- a/examples/add_fail2ban_object.py
+++ b/examples/add_fail2ban_object.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP, MISPEvent
+from pymisp import PyMISP, MISPEvent
 from pymisp.tools import Fail2BanObject
 import argparse
 from base64 import b64decode
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     parser.add_argument("-d", "--disable_new", action='store_true', default=False, help="Do not create a new Event.")
     args = parser.parse_args()
 
-    pymisp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert, debug=True)
+    pymisp = PyMISP(misp_url, misp_key, misp_verifycert, debug=True)
     event_id = -1
     me = None
     if args.force_new:

--- a/examples/add_feed.py
+++ b/examples/add_feed.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP, MISPFeed
+from pymisp import PyMISP, MISPFeed
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     parser.add_argument("-p", "--provider", required=True, help="Provider name")
     args = parser.parse_args()
 
-    pm = ExpandedPyMISP(misp_url, misp_key, misp_verifycert, debug=True)
+    pm = PyMISP(misp_url, misp_key, misp_verifycert, debug=True)
     feed = MISPFeed()
     feed.format = args.format
     feed.url = args.url

--- a/examples/add_filetype_object_from_csv.py
+++ b/examples/add_filetype_object_from_csv.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import csv
-from pymisp import ExpandedPyMISP, MISPObject
+from pymisp import PyMISP, MISPObject
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     parser.add_argument("-f", "--attr_file", required=True, help="Attribute CSV file path")
     args = parser.parse_args()
 
-    pymisp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    pymisp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     f = open(args.attr_file, newline='')
     csv_reader = csv.reader(f, delimiter=";")

--- a/examples/add_generic_object.py
+++ b/examples/add_generic_object.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import json
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from pymisp.tools import GenericObjectGenerator
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
@@ -19,7 +19,7 @@ if __name__ == '__main__':
     parser.add_argument("-l", "--attr_list", required=True, help="List of attributes")
     args = parser.parse_args()
 
-    pymisp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    pymisp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     misp_object = GenericObjectGenerator(args.type.replace("|", "-"))
     misp_object.generate_attributes(json.loads(args.attr_list))

--- a/examples/add_named_attribute.py
+++ b/examples/add_named_attribute.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
@@ -19,7 +19,7 @@ if __name__ == '__main__':
     parser.add_argument("-v", "--value", help="The value of the attribute")
     args = parser.parse_args()
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     event = misp.add_attribute(args.event, {'type': args.type, 'value': args.value}, pythonify=True)
     print(event)

--- a/examples/add_organisations.py
+++ b/examples/add_organisations.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP, MISPOrganisation, MISPSharingGroup
+from pymisp import PyMISP, MISPOrganisation, MISPSharingGroup
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 import csv
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     parser.add_argument("-c", "--csv-import", required=True, help="The CSV file containing the organizations. Format 'orgname,nationality,sector,type,contacts,uuid,local,sharingroup_uuid'")
     args = parser.parse_args()
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     # CSV format
     #   orgname,nationality,sector,type,contacts,uuid,local,sharingroup

--- a/examples/add_ssh_authorized_keys.py
+++ b/examples/add_ssh_authorized_keys.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from pymisp.tools import SSHAuthorizedKeysObject
 import traceback
 from keys import misp_url, misp_key, misp_verifycert
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     parser.add_argument("-p", "--path", required=True, help="Path to process (expanded using glob).")
     args = parser.parse_args()
 
-    pymisp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert, debug=True)
+    pymisp = PyMISP(misp_url, misp_key, misp_verifycert, debug=True)
 
     for f in glob.glob(args.path):
         try:

--- a/examples/add_user.py
+++ b/examples/add_user.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP, MISPUser
+from pymisp import PyMISP, MISPUser
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     parser.add_argument("-r", "--role_id", required=True, help="Role linked to the user.")
     args = parser.parse_args()
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert, 'json')
+    misp = PyMISP(misp_url, misp_key, misp_verifycert, 'json')
 
     user = MISPUser()
     user.email = args.email

--- a/examples/cache_all.py
+++ b/examples/cache_all.py
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 
 from keys import misp_url, misp_key, misp_verifycert
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 
 
 if __name__ == '__main__':
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
     misp.cache_all_feeds()

--- a/examples/create_events.py
+++ b/examples/create_events.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP, MISPEvent
+from pymisp import PyMISP, MISPEvent
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     parser.add_argument("-t", "--threat", type=int, help="The threat level ID of the newly created event, if applicable. [1-4]")
     args = parser.parse_args()
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     event = MISPEvent()
     event.distribution = args.distrib

--- a/examples/cytomic_orion.py
+++ b/examples/cytomic_orion.py
@@ -16,7 +16,7 @@ Fetches the configuration set in the Cytomic Orion enrichment module
 
 '''
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 import os
@@ -519,7 +519,7 @@ if __name__ == '__main__':
 
     module_config = get_config(misp_url, misp_key, misp_verifycert)
     cytomicobj = cytomicobject
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert, debug=cytomicobject.debug)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert, debug=cytomicobject.debug)
 
     cytomicobj.misp = misp
     cytomicobj.args = args

--- a/examples/del.py
+++ b/examples/del.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
@@ -13,7 +13,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     if args.event:
         result = misp.delete_event(args.event)

--- a/examples/delete_user.py
+++ b/examples/delete_user.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
@@ -11,6 +11,6 @@ if __name__ == '__main__':
     parser.add_argument("-i", "--user_id", help="The id of the user you want to delete.")
     args = parser.parse_args()
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     print(misp.delete_user(args.user_id))

--- a/examples/edit_organisation.py
+++ b/examples/edit_organisation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP, MISPOrganisation
+from pymisp import PyMISP, MISPOrganisation
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
@@ -11,7 +11,7 @@ if __name__ == '__main__':
     parser.add_argument("-e", "--email", help="Email linked to the organisation.")
     args = parser.parse_args()
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     org = MISPOrganisation()
     org.id = args.organisation_id

--- a/examples/edit_user.py
+++ b/examples/edit_user.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP, MISPUser
+from pymisp import PyMISP, MISPUser
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     parser.add_argument("-e", "--email", help="Email linked to the account.")
     args = parser.parse_args()
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
     user = MISPUser
     user.id = args.user_id
     user.email = args.email

--- a/examples/events/create_massive_dummy_events.py
+++ b/examples/events/create_massive_dummy_events.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 try:
     from keys import url, key
     verifycert = False
@@ -19,7 +19,7 @@ if __name__ == '__main__':
     parser.add_argument("-a", "--attribute", type=int, help="Number of attributes per event (default 3000)")
     args = parser.parse_args()
 
-    misp = ExpandedPyMISP(url, key, verifycert)
+    misp = PyMISP(url, key, verifycert)
     misp.toggle_global_pythonify()
 
     if args.limit is None:

--- a/examples/falsepositive_disabletoids.py
+++ b/examples/falsepositive_disabletoids.py
@@ -11,7 +11,7 @@ Do inline config in "main"
 
 '''
 
-from pymisp import ExpandedPyMISP, MISPEvent
+from pymisp import PyMISP, MISPEvent
 from keys import misp_url, misp_key, misp_verifycert
 from datetime import datetime
 from datetime import date
@@ -30,7 +30,7 @@ def init(url, key, verifycert):
     '''
         Template to get MISP module started
     '''
-    return ExpandedPyMISP(url, key, verifycert, 'json')
+    return PyMISP(url, key, verifycert, 'json')
 
 
 if __name__ == '__main__':

--- a/examples/feed-generator/generate.py
+++ b/examples/feed-generator/generate.py
@@ -3,7 +3,7 @@
 import sys
 import json
 import os
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from settings import url, key, ssl, outputdir, filters, valid_attribute_distribution_levels
 try:
     from settings import with_distribution
@@ -40,7 +40,7 @@ def init():
         valid_attribute_distributions = [int(v) for v in valid_attribute_distribution_levels]
     except Exception:
         valid_attribute_distributions = [0, 1, 2, 3, 4, 5]
-    return ExpandedPyMISP(url, key, ssl)
+    return PyMISP(url, key, ssl)
 
 
 def saveEvent(event, misp):

--- a/examples/fetch_events_feed.py
+++ b/examples/fetch_events_feed.py
@@ -3,7 +3,7 @@
 
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 
 
 if __name__ == '__main__':
@@ -11,5 +11,5 @@ if __name__ == '__main__':
     parser.add_argument("-f", "--feed", required=True, help="feed's ID to be fetched.")
     args = parser.parse_args()
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
     misp.fetch_feed(args.feed)

--- a/examples/freetext.py
+++ b/examples/freetext.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 

--- a/examples/get.py
+++ b/examples/get.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 import os
@@ -27,7 +27,7 @@ if __name__ == '__main__':
         print('Output file already exists, abort.')
         exit(0)
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert, proxies=proxies)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert, proxies=proxies)
 
     event = misp.get_event(args.event, pythonify=True)
     if args.output:

--- a/examples/get_csv.py
+++ b/examples/get_csv.py
@@ -3,7 +3,7 @@
 
 import argparse
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from keys import misp_url, misp_key, misp_verifycert
 
 
@@ -18,7 +18,7 @@ if __name__ == '__main__':
     parser.add_argument("-f", "--outfile", help="Output file to write the CSV.")
 
     args = parser.parse_args()
-    pymisp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert, debug=True)
+    pymisp = PyMISP(misp_url, misp_key, misp_verifycert, debug=True)
     attr = []
     if args.attribute:
         attr += args.attribute

--- a/examples/last.py
+++ b/examples/last.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from keys import misp_url, misp_key, misp_verifycert
 try:
     from keys import misp_client_cert
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     else:
         misp_client_cert = (misp_client_cert)
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert, cert=misp_client_cert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert, cert=misp_client_cert)
     result = misp.search(publish_timestamp=args.last, limit=args.limit, page=args.page, pythonify=True)
 
     if not result:

--- a/examples/proofpoint_tap.py
+++ b/examples/proofpoint_tap.py
@@ -1,7 +1,7 @@
 import requests
 from requests.auth import HTTPBasicAuth
 import json
-from pymisp import ExpandedPyMISP, MISPEvent
+from pymisp import PyMISP, MISPEvent
 from keys import misp_url, misp_key, misp_verifycert, proofpoint_sp, proofpoint_secret
 import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -11,7 +11,7 @@ if proofpoint_secret == '<proofpoint secret>':
     quit()
 
 # initialize PyMISP and set url for Panorama
-misp = ExpandedPyMISP(url=misp_url, key=misp_key, ssl=misp_verifycert)
+misp = PyMISP(url=misp_url, key=misp_key, ssl=misp_verifycert)
 
 urlSiem = "https://tap-api-v2.proofpoint.com/v2/siem/all"
 

--- a/examples/proofpoint_vap.py
+++ b/examples/proofpoint_vap.py
@@ -1,10 +1,10 @@
 import requests
 import json
-from pymisp import ExpandedPyMISP, MISPEvent, MISPOrganisation
+from pymisp import PyMISP, MISPEvent, MISPOrganisation
 from keys import misp_url, misp_key, misp_verifycert, proofpoint_key
 
 # initialize PyMISP and set url for Panorama
-misp = ExpandedPyMISP(url=misp_url, key=misp_key, ssl=misp_verifycert)
+misp = PyMISP(url=misp_url, key=misp_key, ssl=misp_verifycert)
 
 urlVap = "https://tap-api-v2.proofpoint.com/v2/people/vap?window=30"  # Window can be 14, 30, and 90 Days
 

--- a/examples/sharing_groups.py
+++ b/examples/sharing_groups.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
@@ -9,7 +9,7 @@ import argparse
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Get a list of the sharing groups from the MISP instance.')
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     sharing_groups = misp.sharing_groups(pythonify=True)
     print(sharing_groups)

--- a/examples/show_sightings.py
+++ b/examples/show_sightings.py
@@ -10,7 +10,7 @@ Put this script in crontab to run every day
 
 '''
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from keys import misp_url, misp_key, misp_verifycert
 
 import sys
@@ -29,7 +29,7 @@ def init(url, key, verifycert):
     '''
         Template to get MISP module started
     '''
-    return ExpandedPyMISP(url, key, verifycert, 'json')
+    return PyMISP(url, key, verifycert, 'json')
 
 
 def set_drift_timestamp(drift_timestamp, drift_timestamp_path):

--- a/examples/stats_report.py
+++ b/examples/stats_report.py
@@ -12,7 +12,7 @@ Do inline config in "main"
 
 '''
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 import os
@@ -36,7 +36,7 @@ def init(url, key, verifycert):
     '''
         Template to get MISP module started
     '''
-    return ExpandedPyMISP(url, key, verifycert, 'json')
+    return PyMISP(url, key, verifycert, 'json')
 
 
 def get_data(misp, timeframe, date_from=None, date_to=None):

--- a/examples/tags.py
+++ b/examples/tags.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 import json
@@ -18,7 +18,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     tags = misp.tags(pythonify=True)
     for tag in tags:

--- a/examples/up.py
+++ b/examples/up.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP, MISPEvent
+from pymisp import PyMISP, MISPEvent
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
@@ -13,7 +13,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     me = MISPEvent()
     me.load_file(args.input)

--- a/examples/upload.py
+++ b/examples/upload.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP, MISPEvent, MISPAttribute
+from pymisp import PyMISP, MISPEvent, MISPAttribute
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 from pathlib import Path
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     parser.add_argument("-i", "--info", help="Used to populate the event info field if no event ID supplied.")
     args = parser.parse_args()
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     files = []
     p = Path(args.upload)

--- a/examples/users_list.py
+++ b/examples/users_list.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 from keys import misp_url, misp_key, misp_verifycert
 import argparse
 
@@ -9,7 +9,7 @@ import argparse
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Get a list of the sharing groups from the MISP instance.')
 
-    misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
+    misp = PyMISP(misp_url, misp_key, misp_verifycert)
 
     users_list = misp.users(pythonify=True)
     print(users_list)

--- a/examples/vmray_automation.py
+++ b/examples/vmray_automation.py
@@ -37,7 +37,7 @@ from typing import Any, Dict, List, Optional
 import requests
 
 from keys import misp_key, misp_url, misp_verifycert
-from pymisp import ExpandedPyMISP
+from pymisp import PyMISP
 
 # Suppress those "Unverified HTTPS request is being made"
 import urllib3
@@ -75,7 +75,7 @@ class VMRayAutomation:
         self.misp_url = misp_url.rstrip("/")
         self.misp_key = misp_key
         self.verifycert = verify_cert
-        self.misp = ExpandedPyMISP(misp_url, misp_key, ssl=verify_cert, debug=debug)
+        self.misp = PyMISP(misp_url, misp_key, ssl=verify_cert, debug=debug)
         self.config = {}
         self.tag_incomplete = 'workflow:state="incomplete"'
 


### PR DESCRIPTION
This pull request addresses issue: https://github.com/MISP/PyMISP/issues/1325 .

It was created by running:
```bash
grep -rlZ ExpandedPyMISP . | xargs -0 sed -i 's/ExpandedPyMISP/PyMISP/g'
```
(credit: https://stackoverflow.com/a/22385837/2897386)

...in the `examples` directory.

Please keep in mind that I am not a Python developer and have not tested the altered code in any way.