### PR TITLE
fix: [tools-emailobject] Circumvent crashes when dealing with ms-tnef messages

### DIFF
--- a/pymisp/tools/emailobject.py
+++ b/pymisp/tools/emailobject.py
@@ -222,12 +222,13 @@ class EMailObject(AbstractMISPObjectGenerator):
         for attch in attachments:  # Add attachments at the end.
             if attch.cid not in related_content.keys():
                 _content_type = attch.getStringStream('__substg1.0_370E')
-                maintype, subtype = _content_type.split("/", 1)
-                message.add_attachment(attch.data,
-                                       maintype=maintype,
-                                       subtype=subtype,
-                                       cid=attch.cid,
-                                       filename=attch.longFilename)
+                if _content_type is not None:
+                    maintype, subtype = _content_type.split("/", 1)
+                    message.add_attachment(attch.data,
+                                           maintype=maintype,
+                                           subtype=subtype,
+                                           cid=attch.cid,
+                                           filename=attch.longFilename)
                 if p := message.get_payload():
                     if isinstance(p, list):
                         cur_attach = p[-1]


### PR DESCRIPTION
- Circumvent crashes when dealing with `ms-tnef` messages
- Gracefully handle case where `getStringStream()` cannot find the requested stream