### PR TITLE
make build_complex_query a staticmethod

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -3942,7 +3942,8 @@ class PyMISP:
         response = self._prepare_request('POST', 'tags/removeTagFromObject', data=to_post)
         return self._check_json_response(response)
 
-    def build_complex_query(self, or_parameters: list[SearchType] | None = None,
+    @staticmethod
+    def build_complex_query(or_parameters: list[SearchType] | None = None,
                             and_parameters: list[SearchType] | None = None,
                             not_parameters: list[SearchType] | None = None) -> dict[str, list[SearchType]]:
         '''Build a complex search query. MISP expects a dictionary with AND, OR and NOT keys.'''


### PR DESCRIPTION
The build_complex_query method is needed in Objects that create the query. Since this query builder don't need an access to misp server (single responsibility principle) I propose making build_complex_query a staticmethod. self object is not used in the function either.