### PR TITLE
fix: [openioc] require both search-contexts before merging a composite

### DIFF
--- a/pymisp/tools/openioc.py
+++ b/pymisp/tools/openioc.py
@@ -257,7 +257,7 @@ def set_all_attributes(openioc, misp_event):
             childList = [child.find('context')['search'] for child in childs]
 
             def check_and_add(value1, value2):
-                if (value1 and value2) in childList:
+                if value1 in childList and value2 in childList:
                     if childs[0].find('context')['search'] == value1:
                         attribute_values = set_values(childs[0], childs[1])
                     else:

--- a/tests/test_openioc.py
+++ b/tests/test_openioc.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+from __future__ import annotations
+
+import unittest
+import warnings
+
+from pymisp.tools import openioc
+
+try:
+    from bs4 import XMLParsedAsHTMLWarning  # type: ignore
+    warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
+except ImportError:
+    pass
+
+
+# Two children of an AND-indicator whose combined search-context pair is NOT a
+# defined composite (RegistryItem/Value + FileItem/Md5sum). These must come back
+# as their two individual attributes, not a merged composite.
+NON_COMPOSITE = """<?xml version="1.0" encoding="us-ascii"?>
+<ioc xmlns="http://schemas.mandiant.com/2010/ioc">
+  <short_description>non-composite test</short_description>
+  <definition>
+    <Indicator operator="AND" id="ind-1">
+      <IndicatorItem id="a" condition="is">
+        <Context document="RegistryItem" search="RegistryItem/Value" type="mir"/>
+        <Content type="string">malicious_value</Content>
+      </IndicatorItem>
+      <IndicatorItem id="b" condition="is">
+        <Context document="FileItem" search="FileItem/Md5sum" type="mir"/>
+        <Content type="md5">d41d8cd98f00b204e9800998ecf8427e</Content>
+      </IndicatorItem>
+    </Indicator>
+  </definition>
+</ioc>"""
+
+# A genuine, defined composite pair (FileItem/FileName + FileItem/Md5sum). This
+# must still merge into a single filename|md5 attribute.
+COMPOSITE = """<?xml version="1.0" encoding="us-ascii"?>
+<ioc xmlns="http://schemas.mandiant.com/2010/ioc">
+  <short_description>composite test</short_description>
+  <definition>
+    <Indicator operator="AND" id="ind-2">
+      <IndicatorItem id="a" condition="is">
+        <Context document="FileItem" search="FileItem/FileName" type="mir"/>
+        <Content type="string">evil.exe</Content>
+      </IndicatorItem>
+      <IndicatorItem id="b" condition="is">
+        <Context document="FileItem" search="FileItem/Md5sum" type="mir"/>
+        <Content type="md5">d41d8cd98f00b204e9800998ecf8427e</Content>
+      </IndicatorItem>
+    </Indicator>
+  </definition>
+</ioc>"""
+
+
+class TestOpenIOC(unittest.TestCase):
+
+    def test_non_composite_and_indicator_not_merged(self) -> None:
+        event = openioc.load_openioc(NON_COMPOSITE)
+        by_type = {attr.type: attr.value for attr in event.attributes}
+        # Two distinct, correctly typed attributes, no bogus merged composite.
+        self.assertEqual(len(event.attributes), 2)
+        self.assertEqual(by_type.get('regkey'), 'malicious_value')
+        self.assertEqual(by_type.get('md5'), 'd41d8cd98f00b204e9800998ecf8427e')
+        self.assertNotIn('other', by_type)
+
+    def test_genuine_composite_still_merged(self) -> None:
+        event = openioc.load_openioc(COMPOSITE)
+        self.assertEqual(len(event.attributes), 1)
+        attr = event.attributes[0]
+        self.assertEqual(attr.type, 'filename|md5')
+        self.assertEqual(attr.value, 'evil.exe|d41d8cd98f00b204e9800998ecf8427e')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
While going through the OpenIOC importer I hit a case where an AND-indicator with two children that aren't a real composite pair gets turned into a bogus merged attribute. The composite check reads `if (value1 and value2) in childList`, but Python evaluates `value1 and value2` first, which just returns value2, so only value2 is actually checked against the indicator's search-contexts. If a mapping key's second half happens to match, the two unrelated children are merged into a single `type='other'` attribute (and emitted once per matching mapping key, so it also duplicates), instead of coming through as their two correct individual attributes.

The fix is to check that both search-contexts are present before merging: `if value1 in childList and value2 in childList`. Genuine composites still merge exactly as before.

I added tests/test_openioc.py covering both paths: a non-composite two-child AND-indicator (RegistryItem/Value + FileItem/Md5sum) now yields the two individual regkey and md5 attributes, and a real composite (FileItem/FileName + FileItem/Md5sum) still merges into the single filename|md5 attribute. The new test fails on the current code and passes with the change; the rest of the offline suite is unaffected.

Thanks for taking a look.
