### PR TITLE
fix: block distribution fields on default galaxy clusters

### DIFF
--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -1442,7 +1442,7 @@ class MISPGalaxyCluster(AbstractMISP):
         self.default = kwargs.pop('default', False)
         # If the default field is set, we shouldn't have distribution or sharing group ID set
         if self.default:
-            blocked_fields = ["distribution" "sharing_group_id"]
+            blocked_fields = ["distribution", "sharing_group_id"]
             for field in blocked_fields:
                 if kwargs.get(field, None):
                     raise NewGalaxyClusterError(

--- a/tests/mispevent_testfiles/galaxy.json
+++ b/tests/mispevent_testfiles/galaxy.json
@@ -13,7 +13,7 @@
             "description": "Milk in tea",
             "uuid": "24430dc6-9c27-4b3c-a5e7-6dda478fffa0",
             "distribution": "3",
-            "default": true,
+            "default": false,
             "meta": {
                 "kill_chain": [
                     "tea:black"

--- a/tests/test_galaxy_cluster.py
+++ b/tests/test_galaxy_cluster.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+from __future__ import annotations
+
+import unittest
+
+from pymisp import MISPGalaxyCluster
+from pymisp.exceptions import NewGalaxyClusterError
+
+
+class TestMISPGalaxyCluster(unittest.TestCase):
+
+    def test_default_cluster_rejects_distribution_fields(self) -> None:
+        for field in ("distribution", "sharing_group_id"):
+            with self.subTest(field=field):
+                cluster = MISPGalaxyCluster()
+                with self.assertRaisesRegex(NewGalaxyClusterError, field):
+                    cluster.from_dict(default=True, **{field: 1})


### PR DESCRIPTION
## Summary

- fix the default galaxy cluster blocked-field list so `distribution` and `sharing_group_id` are checked separately
- add regression coverage for both blocked fields
- keep the existing galaxy fixture valid by marking its distributed cluster as non-default

Fixes #1458

## Testing

- `.venv/bin/python -m pytest -q tests/test_galaxy_cluster.py tests/test_mispevent.py` (37 passed, 2 skipped, 2 subtests passed)
- `.venv/bin/pre-commit run --files pymisp/mispevent.py tests/test_galaxy_cluster.py tests/mispevent_testfiles/galaxy.json`
- `.venv/bin/mypy pymisp/mispevent.py tests/test_galaxy_cluster.py`
