### PR TITLE
feat: Add fetchFromAllFeeds

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -2135,6 +2135,11 @@ class PyMISP:
         response = self._prepare_request('GET', f'feeds/fetchFromFeed/{feed_id}')
         return self._check_json_response(response)
 
+    def fetch_all_feeds(self) -> dict[str, Any] | list[dict[str, Any]]:
+        """ Fetch all the feeds: https://www.misp-project.org/openapi/#tag/Feeds/operation/fetchFromAllFeeds"""
+        response = self._prepare_request('GET', f'feeds/fetchFromAllFeeds')
+        return self._check_json_response(response)
+
     def cache_all_feeds(self) -> dict[str, Any] | list[dict[str, Any]]:
         """ Cache all the feeds: https://www.misp-project.org/openapi/#tag/Feeds/operation/cacheFeeds"""
         response = self._prepare_request('GET', 'feeds/cacheFeeds/all')

--- a/tests/testlive_comprehensive.py
+++ b/tests/testlive_comprehensive.py
@@ -2519,6 +2519,9 @@ class TestComprehensive(unittest.TestCase):
         # Cache all enabled feeds
         r = self.admin_misp_connector.cache_all_feeds()
         self.assertEqual(r['message'], 'Feed caching job initiated.')
+        # Fetch all enabled feeds
+        # Cannot test that, it fetches all the events.
+        # r = self.admin_misp_connector.fetch_all_feeds()
         # Compare all enabled feeds
         r = self.admin_misp_connector.compare_feeds()
         # FIXME: https://github.com/MISP/MISP/issues/4834#issuecomment-511890466
@@ -3508,7 +3511,6 @@ class TestComprehensive(unittest.TestCase):
             "favouriteTags/getToggleField",  # TODO
             "feeds/feedCoverage",
             "feeds/importFeeds",
-            "feeds/fetchFromAllFeeds",
             "feeds/getEvent",
             "feeds/previewIndex",  # TODO
             "feeds/previewEvent",  # TODO


### PR DESCRIPTION
This pull request adds support for fetching all feeds at once in the MISP API client and updates the test suite to reflect this new functionality. The main addition is the new `fetch_all_feeds` method in the `pymisp/api.py` file, which enables users to retrieve all feeds in a single call. The test suite is also updated to acknowledge the presence of this method.

**API Enhancements:**

* Added the `fetch_all_feeds` method to the `MISP` API client (`pymisp/api.py`), providing a way to fetch all feeds via the `feeds/fetchFromAllFeeds` endpoint.

**Test Suite Updates:**

* Updated the `missing_methods` test to remove `feeds/fetchFromAllFeeds` from the list of missing endpoints, as it is now implemented (`tests/testlive_comprehensive.py`).
* Added a placeholder in the `test_feeds` test for `fetch_all_feeds`, noting that it cannot be fully tested because it fetches all events (`tests/testlive_comprehensive.py`).

---
**Human Authored:** _No AI code generators (e.g., GitHub Copilot, ChatGPT, Clause) were used in the creation of this Pull Request._