### PR TITLE
prevent unnecessary keyError in add_attribute

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -1073,7 +1073,7 @@ class PyMISP:
                     a.from_dict(**new_attribute['Attribute'])
                     to_return['attributes'].append(a)
             else:
-                for new_attr in new_attribute['Attribute']:
+                for new_attr in new_attribute.get('Attribute', []):
                     a = MISPAttribute()
                     a.from_dict(**new_attr)
                     to_return['attributes'].append(a)


### PR DESCRIPTION
When calling `add_attribute()` with a list of attributes where every attribute is invalid (for example, due to a type mismatch), `_check_json_response()` returns a dictionary containing only an errors key and no Attribute key.

When `pythonify=True`, the code assumes the Attribute key is always present and iterates over `new_attribute['Attribute']`, which raises a `KeyError` in this case.

This change replaces direct indexing with `new_attribute.get('Attribute', [])`, allowing the method to handle error-only responses gracefully while preserving the existing behaviour for successful responses.