### PR TITLE
fix: accept datetime objects for MISPEvent timestamps in from_dict

### DIFF
--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -1947,11 +1947,23 @@ class MISPEvent(AnalystDataBehaviorMixin):
         if kwargs.get('org_id'):
             self.org_id = int(kwargs.pop('org_id'))
         if kwargs.get('timestamp'):
-            self.timestamp = datetime.fromtimestamp(int(kwargs.pop('timestamp')), timezone.utc)
+            ts = kwargs.pop('timestamp')
+            if isinstance(ts, datetime):
+                self.timestamp = ts
+            else:
+                self.timestamp = datetime.fromtimestamp(int(ts), timezone.utc)
         if kwargs.get('publish_timestamp'):
-            self.publish_timestamp = datetime.fromtimestamp(int(kwargs.pop('publish_timestamp')), timezone.utc)
+            ts = kwargs.pop('publish_timestamp')
+            if isinstance(ts, datetime):
+                self.publish_timestamp = ts
+            else:
+                self.publish_timestamp = datetime.fromtimestamp(int(ts), timezone.utc)
         if kwargs.get('sighting_timestamp'):
-            self.sighting_timestamp = datetime.fromtimestamp(int(kwargs.pop('sighting_timestamp')), timezone.utc)
+            ts = kwargs.pop('sighting_timestamp')
+            if isinstance(ts, datetime):
+                self.sighting_timestamp = ts
+            else:
+                self.sighting_timestamp = datetime.fromtimestamp(int(ts), timezone.utc)
         if kwargs.get('sharing_group_id'):
             self.sharing_group_id = int(kwargs.pop('sharing_group_id'))
         if kwargs.get('RelatedEvent'):

--- a/tests/test_mispevent.py
+++ b/tests/test_mispevent.py
@@ -7,7 +7,7 @@ import json
 from io import BytesIO
 import glob
 import hashlib
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 
 from pymisp import (MISPAttribute, MISPEvent, MISPGalaxy, MISPObject, MISPOrganisation,
                     MISPSighting, MISPTag)
@@ -421,6 +421,20 @@ class TestMISPEvent(unittest.TestCase):
         me.attributes[0].first_seen = today
         self.assertEqual(me.attributes[0].first_seen.year, today.year)
         self.assertEqual(me.attributes[0].last_seen, now)
+
+    def test_event_datetime_timestamps(self) -> None:
+        me = MISPEvent()
+        timestamps = {'timestamp': datetime(2021, 1, 1, 12, 30),
+                      'publish_timestamp': datetime(2021, 1, 2, 12, 30),
+                      'sighting_timestamp': datetime(2021, 1, 3, 12, 30)}
+        me.from_dict(info='test', **timestamps)
+        for field, value in timestamps.items():
+            self.assertEqual(getattr(me, field), value)
+        # The integer/string timestamps from a MISP server must still work
+        me2 = MISPEvent()
+        me2.from_dict(info='test', timestamp='1609459200', publish_timestamp=1609545600)
+        self.assertEqual(me2.timestamp, datetime(2021, 1, 1, tzinfo=timezone.utc))
+        self.assertEqual(me2.publish_timestamp, datetime(2021, 1, 2, tzinfo=timezone.utc))
 
     def test_feed(self) -> None:
         me = MISPEvent()


### PR DESCRIPTION
## Summary

MISPEvent.from_dict crashes with an uncaught TypeError when timestamp, publish_timestamp or sighting_timestamp are passed as datetime objects:

\\\
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'datetime.datetime'
\\\

MISPAttribute, MISPObject and MISPEventReport already accept datetime objects for these fields in from_dict, so MISPEvent is inconsistent with its sibling classes. Passing a datetime is natural for a Python API consumer and is exactly what the typed attributes (timestamp: float | int | datetime) advertise.

## Changes

- Handle datetime input in MISPEvent.from_dict for timestamp, publish_timestamp and sighting_timestamp, mirroring the existing handling in MISPAttribute.from_dict and MISPEventReport.from_dict.
- Integer/string timestamps from a MISP server are unchanged.

## Test

Added test_event_datetime_timestamps covering all three fields with datetime input plus a regression check that integer/string timestamps still parse to UTC-aware datetimes.

Tests: test_mispevent.py passes (the pre-existing object-template failures on this environment are unrelated and caused by an uninitialized misp-objects submodule).