### PR TITLE
fix: Support in-memory STIX uploads

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -3596,7 +3596,9 @@ class PyMISP:
         """
         to_post: str | bytes
         if path is not None:
-            if isinstance(path, (str, Path)):
+            if isinstance(path, (BytesIO, StringIO)):
+                to_post = path.getvalue()
+            elif isinstance(path, (str, Path)):
                 with open(path, 'rb') as f:
                     to_post = f.read()
             else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,20 @@
+from io import BytesIO, StringIO
+from unittest.mock import patch
+
+import pytest
+
+from pymisp import PyMISP
+
+
+@pytest.mark.parametrize('pseudofile', [StringIO('{"type": "bundle"}'), BytesIO(b'{"type": "bundle"}')])
+def test_upload_stix_reads_full_pseudofile(pseudofile: StringIO | BytesIO) -> None:
+    misp = PyMISP.__new__(PyMISP)
+    misp.root_url = 'https://example.test/'
+    pseudofile.seek(0, 2)
+
+    with patch.object(misp, '_prepare_request') as prepare_request:
+        misp.upload_stix(pseudofile)
+
+    prepare_request.assert_called_once_with(
+        'POST', 'https://example.test/events/upload_stix/2', data=pseudofile.getvalue()
+    )


### PR DESCRIPTION
Fixes #1165

Read `StringIO` and `BytesIO` uploads with `getvalue()` so their full contents are sent even when the cursor is at EOF after writing.

Adds focused regression coverage for both text and binary in-memory STIX payloads.

Tests:
- `python -m pytest -q tests/test_api.py` (2 passed)
- `python -m mypy pymisp/api.py tests/test_api.py`
- `pre-commit run --files pymisp/api.py tests/test_api.py`
