### PR TITLE
tests: skip modules whose optional extra is not installed

### DIFF
--- a/tests/test_emailobject.py
+++ b/tests/test_emailobject.py
@@ -10,12 +10,21 @@ from pathlib import Path
 from typing import TypeVar
 from zipfile import ZipFile
 
-from pymisp.tools import EMailObject
 from pymisp.exceptions import InvalidMISPObject
+
+# EMailObject is only exported when the email extra is installed. Importing it
+# unguarded makes this module a collection error rather than a skip, which
+# fails the whole run for anyone who installed pymisp without extras.
+try:
+    from pymisp.tools import EMailObject
+    HAS_EMAIL_EXTRA = True
+except ImportError:
+    HAS_EMAIL_EXTRA = False
 
 T = TypeVar('T', bound='TestEmailObject')
 
 
+@unittest.skipUnless(HAS_EMAIL_EXTRA, "requires the email extra")
 class TestEmailObject(unittest.TestCase):
 
     eml_1: BytesIO

--- a/tests/test_fileobject.py
+++ b/tests/test_fileobject.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import unittest
 import json
 from pymisp.tools import FileObject
+from pymisp.tools.fileobject import HAS_MAGIC
 import pathlib
 
 
 class TestFileObject(unittest.TestCase):
+    @unittest.skipUnless(HAS_MAGIC, "requires the fileobjects extra (libmagic)")
     def test_mimeType(self) -> None:
         file_object = FileObject(filepath=pathlib.Path(__file__))
         attributes = json.loads(file_object.to_json())['Attribute']

--- a/tests/test_openioc.py
+++ b/tests/test_openioc.py
@@ -14,6 +14,7 @@ except ImportError:
     pass
 
 
+
 # Two children of an AND-indicator whose combined search-context pair is NOT a
 # defined composite (RegistryItem/Value + FileItem/Md5sum). These must come back
 # as their two individual attributes, not a merged composite.
@@ -54,6 +55,10 @@ COMPOSITE = """<?xml version="1.0" encoding="us-ascii"?>
 </ioc>"""
 
 
+# Every test here calls load_openioc, which raises when bs4 is absent. The
+# import guard above already anticipates bs4 being missing; without this the
+# tests fail instead of skipping.
+@unittest.skipUnless(openioc.has_bs4, "requires the openioc extra (bs4)")
 class TestOpenIOC(unittest.TestCase):
 
     def test_non_composite_and_indicator_not_merged(self) -> None:


### PR DESCRIPTION
Self-found while setting up to work on something else, so there is no issue to link.

## The problem

`pip install -e .` without extras, then `pytest tests/`:

```
ImportError: cannot import name 'EMailObject' from 'pymisp.tools'
ERROR tests/test_emailobject.py
!!!! Interrupted: 1 error during collection !!!!
1 error in 0.14s
```

The run stops at collection, so no test executes at all. Two more modules fail once that is cleared: `test_openioc.py` raises `Exception: You need to install BeautifulSoup` from all its tests, and `test_fileobject.py::test_mimeType` fails with a bare `StopIteration`, because without libmagic the object carries no `mimetype` attribute and `next()` runs off the end.

CI installs every extra, so none of this shows up there. It only hits someone setting the project up.

## The change

Each of the three modules skips when its extra is absent.

`test_emailobject.py` guards the `EMailObject` import and skips the class. `test_openioc.py` skips the class on `openioc.has_bs4`, which the module already imports. `test_fileobject.py` skips the one mimetype test on `HAS_MAGIC`. Both flags are the library's own, so nothing new is introduced to keep in sync.

`test_openioc.py` already wrapped its bs4 warning-filter import in `try/except ImportError`, so the file anticipated bs4 being missing and then failed anyway. This finishes that.

## Before and after

Bare `pip install -e . pytest`, no extras:

```
main         1 error in 0.14s            (collection aborted, 0 tests run)
this branch  80 passed, 35 skipped
```

With every extra installed, matching CI:

```
main         89 passed, 25 skipped, 1 failed
this branch  89 passed, 26 skipped
```

The one moved test is `test_mimeType`, which skips here only because libmagic is absent on this machine. With the fileobjects extra working it runs as before.

`mypy` clean on all three files.

## Scope

Tests only. No library code, no behaviour change, no new dependency.