### PR TITLE
[high] fix: wait for the publish worker in test_search_publish_timestamp

### DIFF
--- a/tests/testlive_comprehensive.py
+++ b/tests/testlive_comprehensive.py
@@ -141,6 +141,29 @@ class TestComprehensive(unittest.TestCase):
         mispevent.add_attribute('text', str(uuid4()))
         return mispevent
 
+    def _wait_until_published(self, event: MISPEvent, timeout: int=30) -> MISPEvent:
+        """Block until the background worker has actually published `event`.
+
+        Since MISP 2.5.40 publishing is handed to a background job, so
+        add_event() returns before publish_timestamp is set. Any assertion on a
+        publication window has to wait for the worker rather than assume the
+        calls made in between took long enough.
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            fetched = self.pub_misp_connector.get_event(event, pythonify=True)
+            if not isinstance(fetched, MISPEvent):
+                self.fail(f'could not re-fetch event while waiting for publication: {fetched}')
+            # publish_timestamp is a plain int (0) until the worker sets it,
+            # and a datetime once pythonify can parse it.
+            published_at = fetched.publish_timestamp
+            if isinstance(published_at, datetime):
+                published_at = published_at.timestamp()
+            if fetched.published and int(published_at or 0):
+                return fetched
+            time.sleep(0.5)
+        self.fail(f'event {event.id} was not published within {timeout}s')
+
     def environment(self) -> tuple[MISPEvent, MISPEvent, MISPEvent]:
         first_event = MISPEvent()
         first_event.info = 'First event - org only - low - completed'
@@ -671,6 +694,13 @@ class TestComprehensive(unittest.TestCase):
         second.publish()
         try:
             first = self.pub_misp_connector.add_event(first, pythonify=True)
+            # The interval assertion at the end needs the two events' publish
+            # timestamps to be at least 5s apart. Publishing is done by a
+            # background worker, so wait until the first event is really
+            # published before creating the second: sleeping a fixed amount
+            # only separates the *creation* times, which is not what is
+            # compared below.
+            first = self._wait_until_published(first)
             time.sleep(10)
             second = self.pub_misp_connector.add_event(second, pythonify=True)
             # Test invalid query
@@ -680,21 +710,28 @@ class TestComprehensive(unittest.TestCase):
             self.assertEqual(events, [])
             events = self.pub_misp_connector.search(publish_timestamp='aaad', pythonify=True)
             self.assertEqual(events, [])
+            # Wait for the background publish worker before asserting on a
+            # 5-second publication window. Without this the assertion races the
+            # worker: it only passed because the three invalid queries above
+            # happened to take long enough, so any speed-up on the server (or a
+            # faster runner) makes the search run first and match nothing.
+            second = self._wait_until_published(second)
             # Test - last 4 min
             events = self.pub_misp_connector.search(publish_timestamp='5s', pythonify=True)
-            self.assertEqual(len(events), 1)
+            self.assertEqual(len(events), 1, events)
             self.assertEqual(events[0].id, second.id)
 
-            # we need to sleep here as per 2.5.40 we've moved the publish timestamp setting to the background process instead of front loading it.
-            # The default tick rate of the background worker is 5s so 10 seconds should be safe-ish. (assuming no other fuck-ups)
-            time.sleep(10)
+            # Both events have already been waited on above, so their
+            # publish_timestamp is a datetime rather than the int 0 that
+            # add_event returns since 2.5.40. That replaces a fixed 10s sleep,
+            # which both slowed the suite down and still raised AttributeError
+            # whenever the worker happened to be slower than the guess.
 
-            # The add_event response no longer carries the publish_timestamp (it is now set by the background
-            # publish job, not synchronously), so the events fetched above still hold publish_timestamp == 0,
-            # which pythonify leaves as a plain int rather than a datetime. Re-fetch them now that the worker
-            # has published so publish_timestamp is populated as a datetime for the .timestamp() calls below.
-            first = self.pub_misp_connector.get_event(first, pythonify=True)
-            second = self.pub_misp_connector.get_event(second, pythonify=True)
+            # The interval assertion below only distinguishes the two events if
+            # their publish timestamps are more than 5s apart. Check it here so
+            # a violation reports the actual gap instead of an opaque count.
+            gap = second.publish_timestamp.timestamp() - first.publish_timestamp.timestamp()
+            self.assertGreater(gap, 5, f'publish timestamps only {gap}s apart')
 
             # Test 5 sec before timestamp of 2nd event
             events = self.pub_misp_connector.search(publish_timestamp=(second.publish_timestamp.timestamp()), pythonify=True)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `test_search_publish_timestamp` races the publish worker and fails whenever the server answers faster.

- **Problem** — It asserts that a `publish_timestamp='5s'` search returns exactly one event immediately after creating it, but since MISP 2.5.40 the publish timestamp is set by a background worker rather than during `add_event`. The assertion only ever passed because the three invalid-query searches before it happened to take longer than the worker's tick.
- **Fix** — Waits for the worker to actually publish instead of relying on that incidental latency, and drops a fixed 10-second sleep that was both slow and still insufficient.
- **Effect** — The test becomes deterministic rather than a race, and stops reporting a server-side speed-up as a test failure.
<!-- /bluf -->

## How this surfaced

MISP/MISP#11081 removes a bcrypt verification from every authenticated REST request. On that branch this test fails reproducibly on both CI legs:

```
FAILED tests/testlive_comprehensive.py::TestComprehensive::test_search_publish_timestamp
  - AssertionError: 0 != 1
```

The runtime of this very suite is the evidence that nothing is actually broken:

| branch | `testlive_comprehensive` (same 85 tests) | result |
|---|---|---|
| the faster-auth branch | **145.6s**, **146.9s** | fails this test |
| six other MISP PRs, 12 runs | 190.3s – 216.7s | all pass |

The faster the server answers, the sooner the three invalid queries return, and the less time the publish worker has had. `0` is the correct answer to the search at that moment — the event genuinely is not published yet.

## Why it is a race

```python
second = self.pub_misp_connector.add_event(second, pythonify=True)
# three invalid publish_timestamp queries, each asserting []
events = self.pub_misp_connector.search(publish_timestamp='5s', pythonify=True)
self.assertEqual(len(events), 1)
```

Nothing between `add_event` and the assertion waits for publication. The three invalid queries are load-bearing purely as a delay, which is not what they were written for. The test's own comment a few lines further down already acknowledges the 2.5.40 change and sleeps for it — but only *after* the assertion that needs it.

## The change

- **`_wait_until_published()`** — polls until the event reports `published` with a non-zero `publish_timestamp`, then returns the re-fetched event. On timeout it fails with `event <id> was not published within <n>s` rather than letting a later assertion fail obscurely. It accepts `publish_timestamp` as either the `int` `0` that `add_event` returns or the `datetime` that `pythonify` produces once the worker has run.
- **Wait for the first event before creating the second.** The interval assertion at the end compares the two *publish* timestamps, but the previous `sleep` only separated their *creation* times.
- **Wait for the second event before the 5-second-window assertion.**
- **Drop the fixed `time.sleep(10)`** that preceded the re-fetch. It slowed the suite down and still raised `AttributeError` on `int.timestamp()` whenever the worker was slower than the guess.
- **Assert the two publish timestamps are more than 5s apart**, so a violation reports the real gap instead of an opaque count mismatch.

## Verification

The helper's control flow was exercised against a stubbed connector, since the surrounding suite needs a live MISP instance:

| case | result |
|---|---|
| unpublished, then published | returns after 3 polls (~1.0s) |
| `published=True` but `publish_timestamp == 0` | keeps waiting, does not return early |
| never publishes | fails after the timeout with `event 42 was not published within 2s` |

The test is now driven by the worker's actual progress, so it neither races a faster server nor pays a fixed delay on a slower one.

MISP/MISP#11081 is blocked on this change and should go green once it is merged and MISP's PyMISP submodule picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


